### PR TITLE
Addresses #14: Add configuration for incoming attachment directory

### DIFF
--- a/mautrix_signal/config.py
+++ b/mautrix_signal/config.py
@@ -55,6 +55,7 @@ class Config(BaseBridgeConfig):
 
         copy("signal.socket_path")
         copy("signal.outgoing_attachment_dir")
+        copy("signal.incoming_attachment_dir")
         copy("signal.avatar_dir")
         copy("signal.remove_file_after_handling")
 

--- a/mautrix_signal/example-config.yaml
+++ b/mautrix_signal/example-config.yaml
@@ -75,6 +75,11 @@ signal:
     # absolute path that signald can read. For attachments in the other direction,
     # make sure signald is configured to use an absolute path as the data directory.
     outgoing_attachment_dir: /tmp
+    # Directory for temp files when receiving files from Signal. For most deployments, this should
+    # not be specified (defaults to use outgoing_attachment_dir). If you're deploying signald and
+    # this bridge in two separate Docker containers, this is the absolute path to the data
+    # directory in signald.
+    # incoming_attachment_dir: /tmp
     # Directory where signald stores avatars for groups.
     avatar_dir: ~/.config/signald/avatars
     # Whether or not message attachments should be removed from disk after they're bridged.


### PR DESCRIPTION
As far as I'm aware, this is exclusively useful in the context of a Docker deployment where signald and mautrix-signal are in different containers AND the paths to their respective data directories are not identical.

This introduces a new configuration item, `incoming_attachment_dir`. When set and receiving/sending attachments, this translates a path from being mautrix-relative to being signald-relative. From an implementation perspective, this is on the "mautrix" side of things (portal.py). It could conceivably be on the "signald" side of things (signald.py) instead I found it was easier to modify the path on creation.

This enables easier integration with the `finn/signald` Docker image. I've tried it out for only basic use cases (sending pictures from Matrix and receiving pictures from Signal), and only for the Docker deployment case.