### PR TITLE
Add groupname_template to change naming of Signal groups

### DIFF
--- a/mautrix_signal/example-config.yaml
+++ b/mautrix_signal/example-config.yaml
@@ -79,6 +79,9 @@ bridge:
     # available variable in displayname_preference. The variables in displayname_preference
     # can also be used here directly.
     displayname_template: "{displayname} (Signal)"
+    # Groupname template for Signal groups.
+    # {} is replaced with the name of the group
+    groupname_template: "{} (Signal)"
     # Whether or not contact list displaynames should be used.
     # Using this isn't recommended on multi-user instances.
     allow_contact_list_name_updates: false

--- a/mautrix_signal/portal.py
+++ b/mautrix_signal/portal.py
@@ -452,9 +452,11 @@ class Portal(DBPortal, BasePortal):
             return
 
         if isinstance(info, Group):
-            changed = await self._update_name(info.name)
+            changed = await self._update_name(
+                    self.config["bridge.groupname_template"].format(info.name))
         elif isinstance(info, GroupV2):
-            changed = await self._update_name(info.title)
+            changed = await self._update_name(
+                    self.config["bridge.groupname_template"].format(info.title))
         elif isinstance(info, GroupV2ID):
             return
         else:


### PR DESCRIPTION
In order to distinguish Signal and Matrix rooms, I found it handy to append "(Signal)" as it is the default for display names in 1:1 chats. I only added another variable in `config.yaml` and changed the `update_info()`-function for `Group` and `GroupV2` instances.