### PR TITLE
Add example config for custom welcome messages

### DIFF
--- a/mautrix_signal/example-config.yaml
+++ b/mautrix_signal/example-config.yaml
@@ -206,7 +206,7 @@ bridge:
         # Sent when joining a management room and the user is not logged in.
         welcome_unconnected: "Use `help` for help or `register` to log in."
         # Optional extra text sent when joining a management room.
-        # additional_help: "This would be some additional text in case you need it."
+        additional_help: ""
 
     # Send each message separately (for readability in some clients)
     management_room_multiple_messages: false


### PR DESCRIPTION
Adds example config to replace the default welcome messages in mautrix/python#58