### PR TITLE
Make it possible to disable device registration from the config

### DIFF
--- a/mautrix_signal/commands/auth.py
+++ b/mautrix_signal/commands/auth.py
@@ -81,6 +81,7 @@ async def link(evt: CommandEvent) -> None:
 
 
 @command_handler(needs_auth=False, management_only=True, help_section=SECTION_AUTH,
+                 is_enabled_for=lambda evt: evt.config["signal.registration_enabled"],
                  help_text="Sign into Signal as the primary device", help_args="<phone>")
 async def register(evt: CommandEvent) -> None:
     if len(evt.args) == 0:

--- a/mautrix_signal/config.py
+++ b/mautrix_signal/config.py
@@ -53,6 +53,7 @@ class Config(BaseBridgeConfig):
         copy("signal.data_dir")
         copy("signal.delete_unknown_accounts_on_start")
         copy("signal.remove_file_after_handling")
+        copy("signal.registration_enabled")
 
         copy("metrics.enabled")
         copy("metrics.listen_port")

--- a/mautrix_signal/example-config.yaml
+++ b/mautrix_signal/example-config.yaml
@@ -102,6 +102,8 @@ signal:
     delete_unknown_accounts_on_start: false
     # Whether or not message attachments should be removed from disk after they're bridged.
     remove_file_after_handling: true
+    # Whether or not users can register a primary device
+    registration_enabled: true
 
 # Bridge config
 bridge:


### PR DESCRIPTION
Handy for running a linked-devices-only bridge, which Signal treats a lot more liberally.