### PR TITLE
Use message send checkpoints

### DIFF
--- a/mautrix_signal/example-config.yaml
+++ b/mautrix_signal/example-config.yaml
@@ -14,6 +14,8 @@ homeserver:
     # If set, the bridge will make POST requests to this URL whenever a user's Signal connection state changes.
     # The bridge will use the appservice as_token to authorize requests.
     status_endpoint: null
+    # Endpoint for reporting per-message status.
+    message_send_checkpoint_endpoint: null
 
 # Application service host/registration related details
 # Changing these values requires regeneration of the registration.

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,5 @@ commonmark>=0.8,<0.10
 aiohttp>=3,<4
 yarl>=1,<2
 attrs>=19.1
-mautrix>=0.11.1,<0.12
+mautrix>=0.11.2,<0.12
 asyncpg>=0.20,<0.25


### PR DESCRIPTION
- Added new config `homeserver.message_send_checkpoint_endpoint`
- Utilized `send_remote_checkpoint` to report success/failure of messages sent to Signal

Depends on https://github.com/mautrix/python/pull/66