### PR TITLE
Add some jitter to the sync loop

### DIFF
--- a/mautrix_signal/__main__.py
+++ b/mautrix_signal/__main__.py
@@ -14,6 +14,7 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 from typing import Dict, Any
+from random import uniform
 import asyncio
 import logging
 
@@ -33,6 +34,7 @@ from .puppet import Puppet
 from .web import ProvisioningAPI
 from . import commands
 
+SYNC_JITTER=10
 
 class SignalBridge(Bridge):
     module = "mautrix_signal"
@@ -92,6 +94,8 @@ class SignalBridge(Bridge):
                 return
             log.info("Executing periodic syncs")
             for user in User.by_username.values():
+                # Add some randomness to the sync to avoid a thundering herd
+                await asyncio.sleep(uniform(-SYNC_JITTER, SYNC_JITTER))
                 try:
                     await user.sync()
                 except asyncio.CancelledError:

--- a/mautrix_signal/__main__.py
+++ b/mautrix_signal/__main__.py
@@ -95,7 +95,7 @@ class SignalBridge(Bridge):
             log.info("Executing periodic syncs")
             for user in User.by_username.values():
                 # Add some randomness to the sync to avoid a thundering herd
-                await asyncio.sleep(uniform(-SYNC_JITTER, SYNC_JITTER))
+                await asyncio.sleep(uniform(0, SYNC_JITTER))
                 try:
                     await user.sync()
                 except asyncio.CancelledError:

--- a/mautrix_signal/__main__.py
+++ b/mautrix_signal/__main__.py
@@ -34,7 +34,7 @@ from .puppet import Puppet
 from .web import ProvisioningAPI
 from . import commands
 
-SYNC_JITTER=10
+SYNC_JITTER = 10
 
 class SignalBridge(Bridge):
     module = "mautrix_signal"


### PR DESCRIPTION
Fixes #168 

This should ensure that sync requests made to signald are appropriately staggered to prevent the process from being hit by a thundering herd of requests. At the moment this is hardcoded to 10s.

There is a risk that this will make the profile sync speed lower than advertised in the config, but overall shouldn't be too noticeable for smaller bridges.