### PR TITLE
disappearing messages: add support for both inbound and outbound

### DIFF
--- a/mautrix_signal/__main__.py
+++ b/mautrix_signal/__main__.py
@@ -68,7 +68,7 @@ class SignalBridge(Bridge):
     async def start(self) -> None:
         User.init_cls(self)
         self.add_startup_actions(Puppet.init_cls(self))
-        Portal.init_cls(self)
+        self.add_startup_actions(Portal.init_cls(self))
         if self.config["bridge.resend_bridge_info"]:
             self.add_startup_actions(self.resend_bridge_info())
         self.add_startup_actions(self.signal.start())

--- a/mautrix_signal/__main__.py
+++ b/mautrix_signal/__main__.py
@@ -68,12 +68,13 @@ class SignalBridge(Bridge):
     async def start(self) -> None:
         User.init_cls(self)
         self.add_startup_actions(Puppet.init_cls(self))
-        self.add_startup_actions(Portal.init_cls(self))
+        Portal.init_cls(self)
         if self.config["bridge.resend_bridge_info"]:
             self.add_startup_actions(self.resend_bridge_info())
         self.add_startup_actions(self.signal.start())
         await super().start()
         self.periodic_sync_task = asyncio.create_task(self._periodic_sync_loop())
+        asyncio.create_task(Portal.start_disappearing_message_expirations())
 
     @staticmethod
     async def _actual_periodic_sync_loop(log: logging.Logger, interval: int) -> None:

--- a/mautrix_signal/config.py
+++ b/mautrix_signal/config.py
@@ -54,6 +54,7 @@ class Config(BaseBridgeConfig):
         copy("signal.delete_unknown_accounts_on_start")
         copy("signal.remove_file_after_handling")
         copy("signal.registration_enabled")
+        copy("signal.enable_disappearing_messages_in_groups")
 
         copy("metrics.enabled")
         copy("metrics.listen_port")

--- a/mautrix_signal/db/__init__.py
+++ b/mautrix_signal/db/__init__.py
@@ -3,6 +3,7 @@ import sqlite3
 import uuid
 
 from .upgrade import upgrade_table
+from .disappearing_message import DisappearingMessage
 from .user import User
 from .puppet import Puppet
 from .portal import Portal
@@ -11,7 +12,7 @@ from .reaction import Reaction
 
 
 def init(db: Database) -> None:
-    for table in (User, Puppet, Portal, Message, Reaction):
+    for table in (User, Puppet, Portal, Message, Reaction, DisappearingMessage):
         table.db = db
 
 
@@ -19,4 +20,5 @@ def init(db: Database) -> None:
 sqlite3.register_adapter(uuid.UUID, lambda u: str(u))
 sqlite3.register_converter("UUID", lambda b: uuid.UUID(b.decode("utf-8") if isinstance(b, bytes) else b))
 
-__all__ = ["upgrade_table", "init", "User", "Puppet", "Portal", "Message", "Reaction"]
+__all__ = ["upgrade_table", "init", "User", "Puppet", "Portal", "Message", "Reaction",
+           "DisappearingMessage"]

--- a/mautrix_signal/db/disappearing_message.py
+++ b/mautrix_signal/db/disappearing_message.py
@@ -59,10 +59,6 @@ class DisappearingMessage:
         await cls.db.execute(q, room_id, event_id)
 
     @classmethod
-    async def delete_all(cls, room_id: RoomID) -> None:
-        await cls.db.execute("DELETE FROM message WHERE room_id=$1", room_id)
-
-    @classmethod
     def _from_row(cls, row: asyncpg.Record) -> "DisappearingMessage":
         return cls(**row)
 

--- a/mautrix_signal/db/disappearing_message.py
+++ b/mautrix_signal/db/disappearing_message.py
@@ -1,0 +1,94 @@
+# mautrix-signal - A Matrix-Signal puppeting bridge
+# Copyright (C) 2021 Sumner Evans
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+from typing import ClassVar, List, Optional, TYPE_CHECKING
+
+from attr import dataclass
+import asyncpg
+
+from mautrix.types import RoomID, EventID
+from mautrix.util.async_db import Database
+
+fake_db = Database.create("") if TYPE_CHECKING else None
+
+
+@dataclass
+class DisappearingMessage:
+    db: ClassVar[Database] = fake_db
+
+    room_id: RoomID
+    mxid: EventID
+    expiration_seconds: int
+    expiration_ts: Optional[int] = None
+
+    async def insert(self) -> None:
+        q = """
+        INSERT INTO disappearing_messages (room_id, mxid, expiration_seconds, expiration_ts)
+        VALUES ($1, $2, $3, $4)
+        """
+        await self.db.execute(q, self.room_id, self.mxid, self.expiration_seconds,
+                              self.expiration_ts)
+
+    async def update(self) -> None:
+        q = """
+        UPDATE disappearing_messages
+        SET expiration_seconds=$3, expiration_ts=$4
+        WHERE room_id=$1 AND mxid=$2
+        """
+        try:
+            await self.db.execute(q, self.room_id, self.mxid, self.expiration_seconds,
+                              self.expiration_ts)
+        except Exception as e:
+            print(e)
+
+    @classmethod
+    async def delete(cls, room_id: RoomID, event_id: EventID) -> None:
+        q = "DELETE from disappearing_messages WHERE room_id=$1 AND mxid=$2"
+        await cls.db.execute(q, room_id, event_id)
+
+    @classmethod
+    async def delete_all(cls, room_id: RoomID) -> None:
+        await cls.db.execute("DELETE FROM message WHERE room_id=$1", room_id)
+
+    @classmethod
+    def _from_row(cls, row: asyncpg.Record) -> "DisappearingMessage":
+        return cls(**row)
+
+    @classmethod
+    async def get(cls, room_id: RoomID, event_id: EventID) -> Optional["DisappearingMessage"]:
+        q = """
+        SELECT room_id, mxid, expiration_seconds, expiration_ts
+          FROM disappearing_messages
+         WHERE room_id = $1
+           AND mxid = $2
+        """
+        try:
+            return cls._from_row(await cls.db.fetchrow(q, room_id, event_id))
+        except Exception:
+            return None
+
+    @classmethod
+    async def get_all(cls) -> List["DisappearingMessage"]:
+        q = "SELECT room_id, mxid, expiration_seconds, expiration_ts FROM disappearing_messages"
+        return [cls._from_row(r) for r in await cls.db.fetch(q)]
+
+    @classmethod
+    async def get_all_for_room(cls, room_id: RoomID) -> List["DisappearingMessage"]:
+        q = """
+        SELECT room_id, mxid, expiration_seconds, expiration_ts
+          FROM disappearing_messages
+         WHERE room_id = $1
+        """
+        return [cls._from_row(r) for r in await cls.db.fetch(q, room_id)]

--- a/mautrix_signal/db/disappearing_message.py
+++ b/mautrix_signal/db/disappearing_message.py
@@ -35,7 +35,7 @@ class DisappearingMessage:
 
     async def insert(self) -> None:
         q = """
-        INSERT INTO disappearing_messages (room_id, mxid, expiration_seconds, expiration_ts)
+        INSERT INTO disappearing_message (room_id, mxid, expiration_seconds, expiration_ts)
         VALUES ($1, $2, $3, $4)
         """
         await self.db.execute(q, self.room_id, self.mxid, self.expiration_seconds,
@@ -43,7 +43,7 @@ class DisappearingMessage:
 
     async def update(self) -> None:
         q = """
-        UPDATE disappearing_messages
+        UPDATE disappearing_message
         SET expiration_seconds=$3, expiration_ts=$4
         WHERE room_id=$1 AND mxid=$2
         """
@@ -55,7 +55,7 @@ class DisappearingMessage:
 
     @classmethod
     async def delete(cls, room_id: RoomID, event_id: EventID) -> None:
-        q = "DELETE from disappearing_messages WHERE room_id=$1 AND mxid=$2"
+        q = "DELETE from disappearing_message WHERE room_id=$1 AND mxid=$2"
         await cls.db.execute(q, room_id, event_id)
 
     @classmethod
@@ -66,7 +66,7 @@ class DisappearingMessage:
     async def get(cls, room_id: RoomID, event_id: EventID) -> Optional["DisappearingMessage"]:
         q = """
         SELECT room_id, mxid, expiration_seconds, expiration_ts
-          FROM disappearing_messages
+          FROM disappearing_message
          WHERE room_id = $1
            AND mxid = $2
         """
@@ -77,14 +77,14 @@ class DisappearingMessage:
 
     @classmethod
     async def get_all(cls) -> List["DisappearingMessage"]:
-        q = "SELECT room_id, mxid, expiration_seconds, expiration_ts FROM disappearing_messages"
+        q = "SELECT room_id, mxid, expiration_seconds, expiration_ts FROM disappearing_message"
         return [cls._from_row(r) for r in await cls.db.fetch(q)]
 
     @classmethod
     async def get_all_for_room(cls, room_id: RoomID) -> List["DisappearingMessage"]:
         q = """
         SELECT room_id, mxid, expiration_seconds, expiration_ts
-          FROM disappearing_messages
+          FROM disappearing_message
          WHERE room_id = $1
         """
         return [cls._from_row(r) for r in await cls.db.fetch(q, room_id)]

--- a/mautrix_signal/db/upgrade.py
+++ b/mautrix_signal/db/upgrade.py
@@ -179,7 +179,7 @@ async def upgrade_v7(conn: Connection) -> None:
 
 @upgrade_table.register(description="Add support for disappearing messages")
 async def upgrade_v8(conn: Connection) -> None:
-    await conn.execute("""CREATE TABLE disappearing_messages (
+    await conn.execute("""CREATE TABLE disappearing_message (
         room_id             TEXT,
         mxid                TEXT,
         expiration_seconds  BIGINT,

--- a/mautrix_signal/db/upgrade.py
+++ b/mautrix_signal/db/upgrade.py
@@ -177,7 +177,7 @@ async def upgrade_v7(conn: Connection) -> None:
     await conn.execute("ALTER TABLE portal ADD COLUMN relay_user_id TEXT")
 
 
-@upgrade_table.register(description="Add table for tracking when to redact disappearing messages")
+@upgrade_table.register(description="Add support for disappearing messages")
 async def upgrade_v8(conn: Connection) -> None:
     await conn.execute("""CREATE TABLE disappearing_messages (
         room_id             TEXT,
@@ -187,8 +187,4 @@ async def upgrade_v8(conn: Connection) -> None:
 
         PRIMARY KEY (room_id, mxid)
     )""")
-
-
-@upgrade_table.register(description="Add expiration_time column to portal table")
-async def upgrade_v9(conn: Connection) -> None:
     await conn.execute("ALTER TABLE portal ADD COLUMN expiration_time BIGINT")

--- a/mautrix_signal/db/upgrade.py
+++ b/mautrix_signal/db/upgrade.py
@@ -175,3 +175,20 @@ async def upgrade_v6(conn: Connection) -> None:
 @upgrade_table.register(description="Add relay user field to portal table")
 async def upgrade_v7(conn: Connection) -> None:
     await conn.execute("ALTER TABLE portal ADD COLUMN relay_user_id TEXT")
+
+
+@upgrade_table.register(description="Add table for tracking when to redact disappearing messages")
+async def upgrade_v8(conn: Connection) -> None:
+    await conn.execute("""CREATE TABLE disappearing_messages (
+        room_id             TEXT,
+        mxid                TEXT,
+        expiration_seconds  BIGINT,
+        expiration_ts       BIGINT,
+
+        PRIMARY KEY (room_id, mxid)
+    )""")
+
+
+@upgrade_table.register(description="Add expiration_time column to portal table")
+async def upgrade_v9(conn: Connection) -> None:
+    await conn.execute("ALTER TABLE portal ADD COLUMN expiration_time BIGINT")

--- a/mautrix_signal/example-config.yaml
+++ b/mautrix_signal/example-config.yaml
@@ -105,6 +105,10 @@ signal:
     remove_file_after_handling: true
     # Whether or not users can register a primary device
     registration_enabled: true
+    # Whether or not to enable disappearing messages in groups. If enabled, then the expiration
+    # time of the messages will be determined by the first users to read the message, rather
+    # than individually. If the bridge has a single user, this can be turned on safely.
+    enable_disappearing_messages_in_groups: false
 
 # Bridge config
 bridge:

--- a/mautrix_signal/matrix.py
+++ b/mautrix_signal/matrix.py
@@ -14,7 +14,6 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 from typing import List, Union, TYPE_CHECKING
-from datetime import datetime
 
 from mautrix.bridge import BaseMatrixHandler
 from mautrix.types import (Event, ReactionEvent, StateEvent, RoomID, EventID, UserID, TypingEvent,

--- a/mautrix_signal/matrix.py
+++ b/mautrix_signal/matrix.py
@@ -14,11 +14,14 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 from typing import List, Union, TYPE_CHECKING
+from datetime import datetime
 
 from mautrix.bridge import BaseMatrixHandler
 from mautrix.types import (Event, ReactionEvent, StateEvent, RoomID, EventID, UserID, TypingEvent,
                            ReactionEventContent, RelationType, EventType, ReceiptEvent,
                            PresenceEvent, RedactionEvent, SingleReceiptEventContent)
+
+from mautrix_signal.db.disappearing_message import DisappearingMessage
 
 from .db import Message as DBMessage
 from . import portal as po, user as u, signal as s
@@ -102,6 +105,8 @@ class MatrixHandler(BaseMatrixHandler):
 
     async def handle_read_receipt(self, user: 'u.User', portal: 'po.Portal', event_id: EventID,
                                   data: SingleReceiptEventContent) -> None:
+        await portal.handle_read_receipt(event_id, data)
+
         message = await DBMessage.get_by_mxid(event_id, portal.mxid)
         if not message:
             return

--- a/mautrix_signal/portal.py
+++ b/mautrix_signal/portal.py
@@ -946,10 +946,9 @@ class Portal(DBPortal, BasePortal):
         self.expiration_time = expires_in_seconds
         await self.update()
 
-        time_str = format_duration(expires_in_seconds)
+        time_str = "Off" if expires_in_seconds is None else format_duration(expires_in_seconds)
         await self.main_intent.send_notice(
             self.mxid,
-            text=f'{sender.name} set the disappearing message timer to {time_str}.',
             html=f'<a href="https://matrix.to/#/{sender.mxid}">{sender.name}</a> set the '
             f'disappearing message timer to {time_str}.'
         )

--- a/mautrix_signal/portal.py
+++ b/mautrix_signal/portal.py
@@ -147,7 +147,7 @@ class Portal(DBPortal, BasePortal):
         self.by_chat_id[(self.chat_id_str, self.receiver)] = self
 
     @classmethod
-    async def init_cls(cls, bridge: 'SignalBridge') -> None:
+    def init_cls(cls, bridge: 'SignalBridge') -> None:
         cls.config = bridge.config
         cls.matrix = bridge.matrix
         cls.signal = bridge.signal
@@ -156,6 +156,8 @@ class Portal(DBPortal, BasePortal):
         BasePortal.bridge = bridge
         cls.private_chat_portal_meta = cls.config["bridge.private_chat_portal_meta"]
 
+    @classmethod
+    async def start_disappearing_message_expirations(cls):
         for dm in await DisappearingMessage.get_all():
             if dm.expiration_ts:
                 asyncio.create_task(cls._expire_event(dm))
@@ -1293,7 +1295,6 @@ class Portal(DBPortal, BasePortal):
             self._main_intent = puppet.default_mxid_intent
         elif not self.is_direct:
             self._main_intent = self.az.intent
-
 
     async def delete(self) -> None:
         await DBMessage.delete_all(self.mxid)

--- a/mautrix_signal/portal.py
+++ b/mautrix_signal/portal.py
@@ -550,6 +550,11 @@ class Portal(DBPortal, BasePortal):
         mechanism to stop the countdown, even after bridge restart.
         """
         room_id = disappearing_message.room_id
+
+        portal = await cls.get_by_mxid(room_id)
+        if not portal:
+            raise AttributeError(f"No portal found for {room_id}")
+
         event_id = disappearing_message.mxid
         wait = disappearing_message.expiration_seconds
         # If there is an expiration_ts, then there was probably a bridge restart, so we have to
@@ -565,10 +570,6 @@ class Portal(DBPortal, BasePortal):
 
         if wait < 0:
             wait = 0
-
-        portal = await cls.get_by_mxid(room_id)
-        if not portal:
-            portal.log.warning(f"No portal for {room_id}")
 
         portal.log.debug(f"Redacting {event_id} in {wait} seconds")
         await asyncio.sleep(wait)

--- a/mautrix_signal/portal.py
+++ b/mautrix_signal/portal.py
@@ -19,7 +19,6 @@ from html import escape as escape_html
 from collections import deque
 from uuid import UUID, uuid4
 from string import Template
-from datetime import datetime
 import mimetypes
 import pathlib
 import hashlib
@@ -555,7 +554,7 @@ class Portal(DBPortal, BasePortal):
         # resume the countdown. This is fairly likely to occur if the disappearance timeout is
         # weeks.
         # If there is not an expiration_ts, then set one.
-        now = datetime.now().timestamp()
+        now = time.time()
         if disappearing_message.expiration_ts is not None:
             wait = (disappearing_message.expiration_ts / 1000) - now
         else:

--- a/mautrix_signal/signal.py
+++ b/mautrix_signal/signal.py
@@ -113,6 +113,8 @@ class SignalHandler(SignaldClient):
             await portal.update_info(user, msg.group)
         if msg.remote_delete:
             await portal.handle_signal_delete(sender, msg.remote_delete.target_sent_timestamp)
+        if msg.expires_in_seconds is not None:
+            await portal.update_expires_in_seconds(sender, msg.expires_in_seconds)
 
     @staticmethod
     async def handle_own_receipts(sender: 'pu.Puppet', receipts: List[OwnReadReceipt]) -> None:

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,5 @@ commonmark>=0.8,<0.10
 aiohttp>=3,<4
 yarl>=1,<2
 attrs>=19.1
-mautrix>=0.13rc1,<0.14
+mautrix>=0.13.0,<0.14
 asyncpg>=0.20,<0.26


### PR DESCRIPTION
When a message is sent or recieved in a Signal chat that has disappearing messages enabled, it will automatically be redacted by the bridge after the time configured on the room. However, note that the countdown timer will only start once the room has been read.

The main mechanism for this is using async functions that just wait the configured number of seconds before redacting. However, there we also store all of the state necessary for determining when to redact a message in the database in case a restart occurs. In the event of a restart, we can resume waiting for the expiration (or redact immediately if we are past the expiration timestamp).

This change also adds m.notice notifications for the user when the disappearing messages setting changes on the Signal chat.