### PR TITLE
Only create matrix rooms on message events

### DIFF
--- a/mautrix_signal/portal.py
+++ b/mautrix_signal/portal.py
@@ -1347,6 +1347,16 @@ class Portal(DBPortal, BasePortal):
             levels.users[self.main_intent.mxid] = 9001 if is_initial else 100
         return levels
 
+    async def ensure_portal_has_room(self, source: u.User, info: ChatInfo, msgTs: int):
+        if self.mxid:
+            return
+        await self.create_matrix_room(
+            source, info
+        )
+        if not self.mxid:
+            raise Exception(f"Failed to create room for incoming message {msgTs}, dropping message")
+
+
     async def _create_matrix_room(self, source: u.User, info: ChatInfo) -> RoomID | None:
         if self.mxid:
             await self._update_matrix_room(source, info)

--- a/mautrix_signal/portal.py
+++ b/mautrix_signal/portal.py
@@ -1350,12 +1350,11 @@ class Portal(DBPortal, BasePortal):
     async def ensure_portal_has_room(self, source: u.User, info: ChatInfo, msgTs: int):
         if self.mxid:
             return
-        await self.create_matrix_room(
-            source, info
-        )
+        await self.create_matrix_room(source, info)
         if not self.mxid:
-            raise Exception(f"Failed to create room for incoming message {msgTs}, dropping message")
-
+            raise Exception(
+                f"Failed to create room for incoming message {msgTs}, dropping message"
+            )
 
     async def _create_matrix_room(self, source: u.User, info: ChatInfo) -> RoomID | None:
         if self.mxid:

--- a/mautrix_signal/signal.py
+++ b/mautrix_signal/signal.py
@@ -122,24 +122,22 @@ class SignalHandler(SignaldClient):
                 )
                 return
         assert portal
-        if not portal.mxid:
-            await portal.create_matrix_room(
-                user, msg.group_v2 or msg.group or addr_override or sender.address
-            )
-            if not portal.mxid:
-                user.log.debug(
-                    f"Failed to create room for incoming message {msg.timestamp}, dropping message"
-                )
-                return
-        elif msg.group_v2 and msg.group_v2.revision > portal.revision:
+
+        if msg.body or msg.attachments or msg.sticker:
+            await portal.ensure_portal_has_room(user, msg.group_v2 or msg.group or addr_override or sender.address, msg.timestamp)
+            await portal.handle_signal_message(user, sender, msg)
+            if msg.expires_in_seconds is not None:
+                await portal.update_expires_in_seconds(sender, msg.expires_in_seconds)
+        elif portal.mxid == None:
+            # The rest of the updates only apply to rooms that exist, so drop
+            portal.log.debug(f"Ignoring message {msg.timestamp}, as portal doesn't exist yet.")
+            return
+
+        if msg.group_v2 and msg.group_v2.revision > portal.revision:
             self.log.debug(f"Got new revision of {msg.group_v2.id}, updating info")
             await portal.update_info(user, msg.group_v2, sender)
         if msg.reaction:
             await portal.handle_signal_reaction(sender, msg.reaction, msg.timestamp)
-        if msg.body or msg.attachments or msg.sticker:
-            await portal.handle_signal_message(user, sender, msg)
-            if msg.expires_in_seconds is not None:
-                await portal.update_expires_in_seconds(sender, msg.expires_in_seconds)
         if msg.group and msg.group.type == "UPDATE":
             await portal.update_info(user, msg.group)
         if msg.remote_delete:

--- a/mautrix_signal/signal.py
+++ b/mautrix_signal/signal.py
@@ -124,7 +124,9 @@ class SignalHandler(SignaldClient):
         assert portal
 
         if msg.body or msg.attachments or msg.sticker:
-            await portal.ensure_portal_has_room(user, msg.group_v2 or msg.group or addr_override or sender.address, msg.timestamp)
+            await portal.ensure_portal_has_room(
+                user, msg.group_v2 or msg.group or addr_override or sender.address, msg.timestamp
+            )
             await portal.handle_signal_message(user, sender, msg)
             if msg.expires_in_seconds is not None:
                 await portal.update_expires_in_seconds(sender, msg.expires_in_seconds)


### PR DESCRIPTION
This PR effectively only creates Matrix rooms on demands when a message is sent into a room, rather than any interaction (like group update, reaction, message deletion).

In practise, I'm hoping this means that fewer empty rooms get created as we've seen a few complaints of users with stale rooms popping up.