### PR TITLE
Fix powerlevels on servers other than synapse

### DIFF
--- a/mautrix_signal/portal.py
+++ b/mautrix_signal/portal.py
@@ -1413,10 +1413,6 @@ class Portal(DBPortal, BasePortal):
                 "state_key": self.bridge_info_state_key,
                 "content": self.bridge_info,
             },
-            {
-                "type": str(EventType.ROOM_POWER_LEVELS),
-                "content": power_levels.serialize(),
-            },
         ]
         invites = []
         if self.config["bridge.encryption.default"] and self.matrix.e2ee:
@@ -1457,6 +1453,7 @@ class Portal(DBPortal, BasePortal):
             initial_state=initial_state,
             invitees=invites,
             creation_content=creation_content,
+            power_level_override=power_levels,
         )
         if not self.mxid:
             raise Exception("Failed to create room: no mxid returned")


### PR DESCRIPTION
This fixes powerlevels initialisation on servers other than synapse, as signal currently follows [this](https://github.com/matrix-org/synapse/issues/11731) behaviour, which is non-spec.

I check the synapse source code against `mautrix.types.state.PowerLevelStateEventContent` to make sure these would match, and no exclusion would result in some other default being added to the room anyways.