### PR TITLE
errors: add AttachmentTooLargeError for attachments over 100MB

### DIFF
--- a/mausignald/errors.py
+++ b/mausignald/errors.py
@@ -77,6 +77,12 @@ class InternalError(ResponseError):
         super().__init__(data, error_type=", ".join(exceptions), message_override=message)
 
 
+class AttachmentTooLargeError(ResponseError):
+    def __init__(self, data: dict[str, Any]) -> None:
+        self.filename = data.get("filename", "")
+        super().__init__(data, message_override="File is over the 100MB limit.")
+
+
 response_error_types = {
     "invalid_request": RequestValidationFailure,
     "TimeoutException": TimeoutException,
@@ -86,6 +92,7 @@ response_error_types = {
     "CaptchaRequired": CaptchaRequired,
     "AuthorizationFailedException": AuthorizationFailedException,
     "InternalError": InternalError,
+    "AttachmentTooLargeError": AttachmentTooLargeError,
     # TODO add rest from https://gitlab.com/signald/signald/-/tree/main/src/main/java/io/finn/signald/exceptions
 }
 

--- a/mautrix_signal/portal.py
+++ b/mautrix_signal/portal.py
@@ -287,6 +287,8 @@ class Portal(DBPortal, BasePortal):
         return str(path)
 
     async def _download_matrix_media(self, message: MediaMessageEventContent) -> str:
+        if message.info.size > 100 * 10**6:
+            raise AttachmentTooLargeError({"filename": message.body})
         if message.file:
             data = await self.main_intent.download_media(message.file.url)
             data = decrypt_attachment(

--- a/mautrix_signal/portal.py
+++ b/mautrix_signal/portal.py
@@ -26,7 +26,7 @@ import os.path
 import pathlib
 import time
 
-from mausignald.errors import NotConnected, RPCError
+from mausignald.errors import AttachmentTooLargeError, NotConnected, RPCError
 from mausignald.types import (
     AccessControlMode,
     Address,
@@ -303,13 +303,13 @@ class Portal(DBPortal, BasePortal):
             await self._handle_matrix_message(sender, message, event_id)
         except Exception as e:
             self.log.exception(f"Failed to handle Matrix message {event_id}")
+            status = (
+                MessageSendCheckpointStatus.UNSUPPORTED
+                if isinstance(e, AttachmentTooLargeError)
+                else MessageSendCheckpointStatus.PERM_FAILURE
+            )
             sender.send_remote_checkpoint(
-                MessageSendCheckpointStatus.PERM_FAILURE,
-                event_id,
-                self.mxid,
-                EventType.ROOM_MESSAGE,
-                message.msgtype,
-                error=e,
+                status, event_id, self.mxid, EventType.ROOM_MESSAGE, message.msgtype, error=e
             )
             await sender.handle_auth_failure(e)
             await self._send_message(


### PR DESCRIPTION
Note that is MB, not MiB.

Requires https://gitlab.com/signald/signald/-/commit/9dd4b1bdde9fb77f872a48ae225b3894e54e7ea6

This also makes AttachmentTooLargeError errors report `UNSUPPORTED` checkpoint status instead of `PERM_FAILURE`:

```
{
    "checkpoints": [
        {
            "event_id": "$Jxs4LnDGVLBB5mGgL6cYFIYWXV0mghQj-stpArWlyMk",
            "room_id": "!qHOnpPioZRtUoyxqds:localhost",
            "step": "REMOTE",
            "timestamp": 1644297992431,
            "status": "UNSUPPORTED",
            "event_type": "m.room.message",
            "reported_by": "BRIDGE",
            "retry_num": 0,
            "message_type": "m.file",
            "info": "File is over the 100MB limit."
        }
    ]
}
```