### PR TITLE
async media: add ability to upload media asynchronously

### DIFF
--- a/mautrix_signal/example-config.yaml
+++ b/mautrix_signal/example-config.yaml
@@ -18,6 +18,9 @@ homeserver:
     message_send_checkpoint_endpoint: null
     # Maximum number of simultaneous HTTP connections to the homeserver.
     connection_limit: 100
+    # Whether asynchronous uploads via MSC2246 should be enabled for media.
+    # Requires a media repo that supports MSC2246.
+    async_media: false
 
 # Application service host/registration related details
 # Changing these values requires regeneration of the registration.

--- a/mautrix_signal/portal.py
+++ b/mautrix_signal/portal.py
@@ -839,7 +839,10 @@ class Portal(DBPortal, BasePortal):
                 upload_mime_type = "application/octet-stream"
 
             upload_uri = await intent.upload_media(
-                data, mime_type=upload_mime_type, filename=link_preview.attachment.id
+                data,
+                mime_type=upload_mime_type,
+                filename=link_preview.attachment.id,
+                async_upload=self.config["homeserver.async_media"],
             )
             if BEEPER_IMAGE_ENCRYPTION_KEY in beeper_link_preview:
                 beeper_link_preview[BEEPER_IMAGE_ENCRYPTION_KEY].url = upload_uri
@@ -1163,7 +1166,12 @@ class Portal(DBPortal, BasePortal):
             data, content.file = encrypt_attachment(data)
             upload_mime_type = "application/octet-stream"
 
-        content.url = await intent.upload_media(data, mime_type=upload_mime_type, filename=id)
+        content.url = await intent.upload_media(
+            data,
+            mime_type=upload_mime_type,
+            filename=id,
+            async_upload=self.config["homeserver.async_media"],
+        )
         if content.file:
             content.file.url = content.url
             content.url = None

--- a/mautrix_signal/puppet.py
+++ b/mautrix_signal/puppet.py
@@ -316,7 +316,7 @@ class Puppet(DBPuppet, BasePuppet):
         new_hash = hashlib.sha256(data).hexdigest()
         if self.avatar_set and new_hash == self.avatar_hash:
             return False
-        mxc = await intent.upload_media(data)
+        mxc = await intent.upload_media(data, async_upload=self.config["homeserver.async_media"])
         return new_hash, mxc
 
     async def _update_avatar(self, path: str) -> bool:

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,5 @@ commonmark>=0.8,<0.10
 aiohttp>=3,<4
 yarl>=1,<2
 attrs>=19.1
-mautrix>=0.15.0,<0.16
+mautrix>=0.15.4,<0.16
 asyncpg>=0.20,<0.26


### PR DESCRIPTION
note that I didn't make the QR code upload async when using the bot commands