### PR TITLE
provisioning api: add start new PM and list contacts endpoints

### DIFF
--- a/mausignald/errors.py
+++ b/mausignald/errors.py
@@ -102,6 +102,10 @@ class AttachmentTooLargeError(ResponseError):
         super().__init__(data, message_override="File is over the 100MB limit.")
 
 
+class UnregisteredUserError(ResponseError):
+    pass
+
+
 response_error_types = {
     "invalid_request": RequestValidationFailure,
     "TimeoutException": TimeoutException,
@@ -114,6 +118,7 @@ response_error_types = {
     "AuthorizationFailedError": AuthorizationFailedError,
     "ScanTimeoutError": ScanTimeoutError,
     "OwnProfileKeyDoesNotExistError": OwnProfileKeyDoesNotExistError,
+    "UnregisteredUserError": UnregisteredUserError,
     # TODO add rest from https://gitlab.com/signald/signald/-/tree/main/src/main/java/io/finn/signald/clientprotocol/v1/exceptions
 }
 

--- a/mautrix_signal/util/__init__.py
+++ b/mautrix_signal/util/__init__.py
@@ -1,2 +1,3 @@
 from .color_log import ColorFormatter
 from .id_to_str import id_to_str
+from .normalize_number import normalize_number

--- a/mautrix_signal/util/normalize_number.py
+++ b/mautrix_signal/util/normalize_number.py
@@ -1,0 +1,24 @@
+# mautrix-signal - A Matrix-Signal puppeting bridge
+# Copyright (C) 2022 Tulir Asokan, Sumner Evans
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+remove_extra_chars = str.maketrans("", "", " .,-()")
+
+
+def normalize_number(number: str) -> str:
+    phone = number.translate(remove_extra_chars)
+    if not number.startswith("+") or not phone[1:].isdecimal():
+        raise Exception("Phone number must be entered in international format")
+    return phone

--- a/mautrix_signal/web/provisioning_api.py
+++ b/mautrix_signal/web/provisioning_api.py
@@ -391,8 +391,10 @@ class ProvisioningAPI:
             except UnregisteredUserError:
                 error = {"error": f"The phone number {number} is not a registered Signal account"}
                 raise web.HTTPNotFound(text=json.dumps(error), headers=self._headers)
-            except Exception as e:
-                raise web.HTTPBadRequest(reason=str(e), headers=self._headers)
+            except Exception:
+                self.log.exception(f"Unknown error fetching UUID for {puppet.number}")
+                error = {"error": "Unknown error while fetching UUID"}
+                raise web.HTTPInternalServerError(text=json.dumps(error), headers=self._headers)
 
         portal = await po.Portal.get_by_chat_id(
             puppet.address, receiver=user.username, create=True


### PR DESCRIPTION
The start new PM endpoint allows you to create PMs with a Signal-registered phone number.

Example usage:

```
  curl -X POST \
    -H 'Authorization: Bearer PROVISIONING_TOKEN_HERE' \
    'http://your.matrix.server.url/_matrix/provision/v2/pm/+11234567890?user_id=@test:localhost'
```

The list contacts endpoint allows you to list contacts for your Signal user:

Example usage:

```
  curl -X GET \
    -H 'Authorization: Bearer PROVISIONING_TOKEN_HERE' \
    'http://your.matrix.server.url/_matrix/provision/v2/contacts?user_id=@test:localhost'
```