### PR TITLE
resolve identifier: fix error when phone number entered incorrectly

### DIFF
--- a/mautrix_signal/web/provisioning_api.py
+++ b/mautrix_signal/web/provisioning_api.py
@@ -384,7 +384,10 @@ class ProvisioningAPI:
         )
 
     async def _resolve_identifier(self, number: str, user: u.User) -> pu.Puppet:
-        number = normalize_number(number)
+        try:
+            number = normalize_number(number)
+        except Exception as e:
+            raise web.HTTPBadRequest(text=json.dumps({"error": str(e)}), headers=self._headers)
 
         puppet: pu.Puppet = await pu.Puppet.get_by_address(Address(number=number))
         assert puppet, "Puppet.get_by_address with create=True can't return None"


### PR DESCRIPTION
```
$ curl 'http://localhost:29328/_matrix/provision/v2/resolve_identifier/11234567890?user_id=@sumner:localhost' -H 'Authorization: Bearer XXXXXXX'
{"error": "Phone number must be entered in international format"}
```