### PR TITLE
add support for kick/ban/unban

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -17,11 +17,11 @@
   * [x] Group info changes
     * [x] Name
     * [x] Avatar
-  * [ ] Membership actions
+  * [x] Membership actions
     * [x] Join (accept invite)
     * [x] Invite
     * [x] Leave
-    * [ ] Kick
+    * [x] Kick/Ban/Unban
   * [ ] Typing notifications
   * [ ] Read receipts (currently partial support, only marks last message)
   * [x] Delivery receipts (sent after message is bridged)

--- a/mausignald/signald.py
+++ b/mausignald/signald.py
@@ -343,6 +343,28 @@ class SignaldClient(SignaldRPCClient):
     async def leave_group(self, username: str, group_id: GroupID) -> None:
         await self.request_v1("leave_group", account=username, groupID=group_id)
 
+    async def ban_user(
+        self, username: str, group_id: GroupID, users: list[Address]
+    ) -> Group | GroupV2:
+        serialized_users = [user.serialize() for user in (users or [])]
+        resp = await self.request_v1(
+            "ban_user", account=username, group_id=group_id, users=serialized_users
+        )
+        legacy = [Group.deserialize(group) for group in resp.get("legacyGroups", [])]
+        v2 = [GroupV2.deserialize(group) for group in resp.get("groups", [])]
+        return legacy + v2
+
+    async def unban_user(
+        self, username: str, group_id: GroupID, users: list[Address]
+    ) -> Group | GroupV2:
+        serialized_users = [user.serialize() for user in (users or [])]
+        resp = await self.request_v1(
+            "unban_user", account=username, group_id=group_id, users=serialized_users
+        )
+        legacy = [Group.deserialize(group) for group in resp.get("legacyGroups", [])]
+        v2 = [GroupV2.deserialize(group) for group in resp.get("groups", [])]
+        return legacy + v2
+
     async def update_group(
         self,
         username: str,

--- a/mausignald/types.py
+++ b/mausignald/types.py
@@ -236,6 +236,7 @@ class GroupV2(GroupV2ID, SerializableAttrs):
     )
     requesting_members: List[Address] = field(factory=lambda: [], json="requestingMembers")
     announcements: AnnouncementsMode = field(default=AnnouncementsMode.UNKNOWN)
+    banned_members: Optional[str] = None
 
 
 @dataclass

--- a/mausignald/types.py
+++ b/mausignald/types.py
@@ -217,6 +217,12 @@ class GroupMember(SerializableAttrs):
     role: GroupMemberRole = GroupMemberRole.UNKNOWN
 
 
+@dataclass
+class BannedGroupMember(SerializableAttrs):
+    uuid: UUID
+    timestamp: int
+
+
 @dataclass(kw_only=True)
 class GroupV2(GroupV2ID, SerializableAttrs):
     title: str
@@ -236,7 +242,7 @@ class GroupV2(GroupV2ID, SerializableAttrs):
     )
     requesting_members: List[Address] = field(factory=lambda: [], json="requestingMembers")
     announcements: AnnouncementsMode = field(default=AnnouncementsMode.UNKNOWN)
-    banned_members: Optional[str] = None
+    banned_members: Optional[List[BannedGroupMember]] = None
 
 
 @dataclass

--- a/mautrix_signal/matrix.py
+++ b/mautrix_signal/matrix.py
@@ -119,7 +119,7 @@ class MatrixHandler(BaseMatrixHandler):
                 await portal.unbridge()
             return
 
-        sender = await u.User.get_by_mxid(sender, create=False)
+        sender = await u.User.get_by_mxid(sender)
         if not await sender.is_logged_in() and portal.has_relay:
             sender = portal.relay_user_id
         if not sender:

--- a/mautrix_signal/matrix.py
+++ b/mautrix_signal/matrix.py
@@ -138,13 +138,11 @@ class MatrixHandler(BaseMatrixHandler):
     async def handle_kick(
         self, room_id: RoomID, user_id: UserID, kicked_by: UserID, reason: str, event_id: EventID
     ) -> None:
-
         await self.handle_kick_ban("kicked", room_id, user_id, kicked_by, reason, event_id)
 
     async def handle_unban(
         self, room_id: RoomID, user_id: UserID, unbanned_by: UserID, reason: str, event_id: EventID
     ) -> None:
-        # TODO handle unbans properly instead of handling it as a kick
         await self.handle_kick_ban("unbanned", room_id, user_id, unbanned_by, reason, event_id)
 
     async def handle_ban(

--- a/mautrix_signal/matrix.py
+++ b/mautrix_signal/matrix.py
@@ -120,11 +120,11 @@ class MatrixHandler(BaseMatrixHandler):
             return
 
         sender = await u.User.get_by_mxid(sender, create=False)
+        if not await sender.is_logged_in() and portal.has_relay:
+            sender = portal.relay_user_id
         if not sender:
             return
 
-        if not await sender.is_logged_in() and portal.has_relay:
-            sender = portal.relay_user_id
         user = await pu.Puppet.get_by_mxid(user_id)
         if not user:
             user = await u.User.get_by_mxid(user_id, create=False)

--- a/mautrix_signal/matrix.py
+++ b/mautrix_signal/matrix.py
@@ -120,8 +120,7 @@ class MatrixHandler(BaseMatrixHandler):
             return
 
         sender = await u.User.get_by_mxid(sender)
-        if not await sender.is_logged_in() and portal.has_relay:
-            sender = portal.relay_user_id
+        sender, is_relay = await self.get_relay_sender(sender, "kick/ban")
         if not sender:
             return
 

--- a/mautrix_signal/matrix.py
+++ b/mautrix_signal/matrix.py
@@ -120,7 +120,7 @@ class MatrixHandler(BaseMatrixHandler):
             return
 
         sender = await u.User.get_by_mxid(sender)
-        sender, is_relay = await self.get_relay_sender(sender, "kick/ban")
+        sender, is_relay = await portal.get_relay_sender(sender, "kick/ban")
         if not sender:
             return
 

--- a/mautrix_signal/matrix.py
+++ b/mautrix_signal/matrix.py
@@ -116,13 +116,15 @@ class MatrixHandler(BaseMatrixHandler):
 
         if user_id == self.az.bot_mxid:
             if portal.is_direct:
-                await portal.cleanup_and_delete()
+                await portal.unbridge()
             return
 
         sender = await u.User.get_by_mxid(sender, create=False)
         if not sender:
             return
 
+        if not await sender.is_logged_in() and portal.has_relay:
+            sender = portal.relay_user_id
         user = await pu.Puppet.get_by_mxid(user_id)
         if not user:
             user = await u.User.get_by_mxid(user_id, create=False)

--- a/mautrix_signal/matrix.py
+++ b/mautrix_signal/matrix.py
@@ -126,7 +126,7 @@ class MatrixHandler(BaseMatrixHandler):
         user = await pu.Puppet.get_by_mxid(user_id)
         if not user:
             user = await u.User.get_by_mxid(user_id, create=False)
-            if not user:
+            if not user or not await user.is_logged_in():
                 return
         if action == "banned":
             await portal.ban_matrix(user, sender)

--- a/mautrix_signal/portal.py
+++ b/mautrix_signal/portal.py
@@ -732,18 +732,24 @@ class Portal(DBPortal, BasePortal):
             )
         except Exception as e:
             self.log.exception(f"Failed to kick Signal user: {e}")
-            await self.main_intent.invite_user(
-                self.mxid, user.mxid, check_cache=True, reason=f"Failed to kick Signal user: {e}"
-            )
-            await user.intent_for(self).ensure_joined(self.mxid)
+            info = await self.signal.get_group(source.username, self.chat_id)
+            if user.address in info.members:
+                await self.main_intent.invite_user(
+                    self.mxid,
+                    user.mxid,
+                    check_cache=True,
+                    reason=f"Failed to kick Signal user: {e}",
+                )
+                await user.intent_for(self).ensure_joined(self.mxid)
 
     async def ban_matrix(self, user: u.User | p.Puppet, source: u.User) -> None:
         try:
             await self.signal.ban_user(source.username, self.chat_id, users=[user.address])
         except Exception as e:
             self.log.exception(f"Failed to ban Signal user: {e}")
-            await self.main_intent.unban_user(self.mxid, user.mxid)
             info = await self.signal.get_group(source.username, self.chat_id)
+            if user.address not in info.banned_members:
+                await self.main_intent.unban_user(self.mxid, user.mxid)
             if user.address in info.members:
                 await self.main_intent.invite_user(
                     self.mxid,
@@ -758,9 +764,11 @@ class Portal(DBPortal, BasePortal):
             await self.signal.unban_user(source.username, self.chat_id, users=[user.address])
         except Exception as e:
             self.log.exception(f"Failed to unban Signal user: {e}")
-            await self.main_intent.ban_user(
-                self.mxid, user.mxid, reason=f"Failed to unban Signal user: {e}"
-            )
+            info = await self.signal.get_group(source.username, self.chat_id)
+            if user.address in info.banned_members:
+                await self.main_intent.ban_user(
+                    self.mxid, user.mxid, reason=f"Failed to unban Signal user: {e}"
+                )
 
     async def handle_matrix_invite(self, invited_by: u.User, user: u.User | p.Puppet) -> None:
         if self.is_direct:

--- a/mautrix_signal/portal.py
+++ b/mautrix_signal/portal.py
@@ -725,6 +725,29 @@ class Portal(DBPortal, BasePortal):
                 await self.signal.leave_group(user.username, self.chat_id)
             # TODO cleanup if empty
 
+    async def kick_matrix(self, user: u.User | p.Puppet, source: u.User) -> None:
+        try:
+            await self.signal.update_group(
+                source.username, self.chat_id, remove_members=[user.address]
+            )
+        except Exception as e:
+            self.log.exception(f"Failed to kick Signal user: {e}")
+            # bridge bot should probable re-invite puppet
+
+    async def ban_matrix(self, user: u.User | p.Puppet, source: u.User) -> None:
+        try:
+            await self.signal.ban_user(source.username, self.chat_id, users=[user.address])
+        except Exception as e:
+            self.log.exception(f"Failed to ban Signal user: {e}")
+            # bridge bot should probable unban puppet
+
+    async def unban_matrix(self, user: u.User | p.Puppet, source: u.User) -> None:
+        try:
+            await self.signal.unban_user(source.username, self.chat_id, users=[user.address])
+        except Exception as e:
+            self.log.exception(f"Failed to unban Signal user: {e}")
+            # bridge bot should probable reban puppet
+
     async def handle_matrix_invite(self, invited_by: u.User, user: u.User | p.Puppet) -> None:
         if self.is_direct:
             raise RejectMatrixInvite("You can't invite additional users to private chats.")

--- a/mautrix_signal/portal.py
+++ b/mautrix_signal/portal.py
@@ -732,21 +732,35 @@ class Portal(DBPortal, BasePortal):
             )
         except Exception as e:
             self.log.exception(f"Failed to kick Signal user: {e}")
-            # bridge bot should probable re-invite puppet
+            await self.main_intent.invite_user(
+                self.mxid, user.mxid, check_cache=True, reason=f"Failed to kick Signal user: {e}"
+            )
+            await user.intent_for(self).ensure_joined(self.mxid)
 
     async def ban_matrix(self, user: u.User | p.Puppet, source: u.User) -> None:
         try:
             await self.signal.ban_user(source.username, self.chat_id, users=[user.address])
         except Exception as e:
             self.log.exception(f"Failed to ban Signal user: {e}")
-            # bridge bot should probable unban puppet
+            await self.main_intent.unban_user(self.mxid, user.mxid)
+            info = await self.signal.get_group(source.username, self.chat_id)
+            if user.address in info.members:
+                await self.main_intent.invite_user(
+                    self.mxid,
+                    user.mxid,
+                    check_cache=True,
+                    reason=f"Failed to ban Signal user: {e}",
+                )
+                await user.intent_for(self).ensure_joined(self.mxid)
 
     async def unban_matrix(self, user: u.User | p.Puppet, source: u.User) -> None:
         try:
             await self.signal.unban_user(source.username, self.chat_id, users=[user.address])
         except Exception as e:
             self.log.exception(f"Failed to unban Signal user: {e}")
-            # bridge bot should probable reban puppet
+            await self.main_intent.ban_user(
+                self.mxid, user.mxid, reason=f"Failed to unban Signal user: {e}"
+            )
 
     async def handle_matrix_invite(self, invited_by: u.User, user: u.User | p.Puppet) -> None:
         if self.is_direct:

--- a/mautrix_signal/portal.py
+++ b/mautrix_signal/portal.py
@@ -748,14 +748,15 @@ class Portal(DBPortal, BasePortal):
         except Exception as e:
             self.log.exception(f"Failed to ban Signal user: {e}")
             info = await self.signal.get_group(source.username, self.chat_id)
-            if user.address not in info.banned_members:
-                await self.main_intent.unban_user(self.mxid, user.mxid)
+            if not info.banned_members or user.address not in info.banned_members:
+                await self.main_intent.unban_user(
+                    self.mxid, user.mxid, reason=f"Failed to ban Signal user: {e}"
+                )
             if user.address in info.members:
                 await self.main_intent.invite_user(
                     self.mxid,
                     user.mxid,
                     check_cache=True,
-                    reason=f"Failed to ban Signal user: {e}",
                 )
                 await user.intent_for(self).ensure_joined(self.mxid)
 
@@ -765,7 +766,7 @@ class Portal(DBPortal, BasePortal):
         except Exception as e:
             self.log.exception(f"Failed to unban Signal user: {e}")
             info = await self.signal.get_group(source.username, self.chat_id)
-            if user.address in info.banned_members:
+            if info.banned_members and user.address in info.banned_members:
                 await self.main_intent.ban_user(
                     self.mxid, user.mxid, reason=f"Failed to unban Signal user: {e}"
                 )


### PR DESCRIPTION
Seems to work just fine.

We might have to think about power levels for kicking/banning/unbanning, because on signal, an `ADMINISTRATOR` can perform those actions on another `ADMINISTRATOR`, whereas matrix does not allow this if power levels are the same. I was thinking we could give a power level of 51 to matrix users, so they will be able to kick puppets, while Signal users can kick matrix users through the bridge bot.