### PR TITLE
add support for matrix -> signal power level changes

### DIFF
--- a/mausignald/signald.py
+++ b/mausignald/signald.py
@@ -355,6 +355,7 @@ class SignaldClient(SignaldRPCClient):
         add_members: list[Address] | None = None,
         remove_members: list[Address] | None = None,
         update_access_control: GroupAccessControl | None = None,
+        update_role: GroupMember | None = None,
     ) -> Group | GroupV2 | None:
         update_params = {
             key: value
@@ -370,6 +371,7 @@ class SignaldClient(SignaldRPCClient):
                 "updateAccessControl": (
                     update_access_control.serialize() if update_access_control else None
                 ),
+                "updateRole": (update_role.serialize() if update_role else None),
             }.items()
             if value is not None
         }

--- a/mautrix_signal/matrix.py
+++ b/mautrix_signal/matrix.py
@@ -188,7 +188,12 @@ class MatrixHandler(BaseMatrixHandler):
             await super().handle_ephemeral_event(evt)
 
     async def handle_state_event(self, evt: StateEvent) -> None:
-        if evt.type not in (EventType.ROOM_NAME, EventType.ROOM_TOPIC, EventType.ROOM_AVATAR):
+        if evt.type not in (
+            EventType.ROOM_NAME,
+            EventType.ROOM_TOPIC,
+            EventType.ROOM_AVATAR,
+            EventType.ROOM_POWER_LEVELS,
+        ):
             return
 
         user = await u.User.get_by_mxid(evt.sender)
@@ -204,6 +209,8 @@ class MatrixHandler(BaseMatrixHandler):
             await portal.handle_matrix_avatar(user, evt.content.url)
         elif evt.type == EventType.ROOM_TOPIC:
             await portal.handle_matrix_topic(user, evt.content.topic)
+        elif evt.type == EventType.ROOM_POWER_LEVELS:
+            await portal.handle_matrix_power_level(user, evt.content, evt.unsigned.prev_content)
 
     async def allow_message(self, user: u.User) -> bool:
         return user.relay_whitelisted

--- a/mautrix_signal/matrix.py
+++ b/mautrix_signal/matrix.py
@@ -196,14 +196,11 @@ class MatrixHandler(BaseMatrixHandler):
         ):
             return
 
+        user = await u.User.get_by_mxid(evt.sender)
+        if not user:
+            return
         portal = await po.Portal.get_by_mxid(evt.room_id)
         if not portal:
-            return
-
-        user = await u.User.get_by_mxid(evt.sender)
-        if not await user.is_logged_in() and portal.has_relay:
-            user = portal.relay_user_id
-        if not user:
             return
 
         if evt.type == EventType.ROOM_NAME:

--- a/mautrix_signal/matrix.py
+++ b/mautrix_signal/matrix.py
@@ -196,11 +196,14 @@ class MatrixHandler(BaseMatrixHandler):
         ):
             return
 
-        user = await u.User.get_by_mxid(evt.sender)
-        if not user:
-            return
         portal = await po.Portal.get_by_mxid(evt.room_id)
         if not portal:
+            return
+
+        user = await u.User.get_by_mxid(evt.sender)
+        if not await user.is_logged_in() and portal.has_relay:
+            user = portal.relay_user_id
+        if not user:
             return
 
         if evt.type == EventType.ROOM_NAME:

--- a/mautrix_signal/portal.py
+++ b/mautrix_signal/portal.py
@@ -878,7 +878,7 @@ class Portal(DBPortal, BasePortal):
                 )
                 self.revision = update_meta.revision
             except Exception as e:
-                self.log.exception(f"Failed to update Signal GroupAccessControl: {e}")
+                self.log.exception(f"Failed to update Signal member add permission: {e}")
                 await self._update_power_levels(
                     await self.signal.get_group(sender.username, self.chat_id)
                 )

--- a/mautrix_signal/portal.py
+++ b/mautrix_signal/portal.py
@@ -899,7 +899,7 @@ class Portal(DBPortal, BasePortal):
                 )
                 self.revision = update_meta.revision
             except Exception as e:
-                self.log.exception(f"Failed to update Signal GroupAccessControl: {e}")
+                self.log.exception(f"Failed to update Signal metadata change permission: {e}")
                 await self._update_power_levels(
                     await self.signal.get_group(sender.username, self.chat_id)
                 )

--- a/mautrix_signal/portal.py
+++ b/mautrix_signal/portal.py
@@ -824,6 +824,10 @@ class Portal(DBPortal, BasePortal):
         old_users = prev_content.users if prev_content else None
         new_users = levels.users
         changes = {}
+        sender, is_relay = await self.get_relay_sender(sender, "power level change")
+        if not sender:
+            return
+
         if not old_users:
             changes = new_users
         else:
@@ -861,6 +865,7 @@ class Portal(DBPortal, BasePortal):
                     await self._update_power_levels(
                         await self.signal.get_group(sender.username, self.chat_id)
                     )
+                    return
         if not prev_content or levels.invite != prev_content.invite:
             try:
                 update_meta = await self.signal.update_group(
@@ -882,6 +887,7 @@ class Portal(DBPortal, BasePortal):
                 await self._update_power_levels(
                     await self.signal.get_group(sender.username, self.chat_id)
                 )
+                return
         if not prev_content or levels.state_default != prev_content.state_default:
             try:
                 update_meta = await self.signal.update_group(

--- a/mautrix_signal/portal.py
+++ b/mautrix_signal/portal.py
@@ -819,7 +819,7 @@ class Portal(DBPortal, BasePortal):
         self,
         sender: u.User,
         levels: PowerLevelStateEventContent,
-        prev_content=None,
+        prev_content: PowerLevelStateEventContent | None = None,
     ) -> None:
         old_users = prev_content.users if prev_content else None
         new_users = levels.users


### PR DESCRIPTION
make Signal role ADMINISTRATOR if power level >= 50
make Signal role DEFAULT if power level <50
bridge `invite` and `state_default` upon explicit changes

works for group creation, invites or explicit power level changes