### PR TITLE
tolerate ranges of power levels for logged-in users to avoid conflicts

### DIFF
--- a/mautrix_signal/portal.py
+++ b/mautrix_signal/portal.py
@@ -1696,7 +1696,7 @@ class Portal(DBPortal, BasePortal):
                     current_level = levels.get_user_level(puppet_mxid)
                     if bot_pl > current_level and bot_pl >= 50:
                         level = current_level
-                        if await u.User.get_by_address(Address(uuid=detail.uuid)):
+                        if puppet.is_real_user:
                             if current_level >= 50 and detail.role == GroupMemberRole.DEFAULT:
                                 level = 0
                             elif (


### PR DESCRIPTION
Fixes #258

for logged-in users:
for DEFAULT, the power level is between 0 and 49
for ADMINISTRATOR, the power level is >50
The bot will only change the power level if it is outside those ranges.

for signal puppets, nothing changes.

If the current power level of the user is higher than that of the bridge bot, don't attempt to change it. While the power level may have to be changed, it's pointless to try.
Likewise, if the bot power level is <50, it won't be able to do anything useful and it's pointless to try. We already print a warning for that.

This PR avoids conflicts with other bridges trying to set different power levels (pl 75 is default for the group creator in telegram, in whatsapp it's 95). It will also allow setting power levels even if they can't be set for some users. Previously, a single, impossible power level change would make the entire command fail, causing no power level changes to be made.