### PR TITLE
Remove duplicate blurhash key

### DIFF
--- a/mautrix_signal/portal.py
+++ b/mautrix_signal/portal.py
@@ -916,7 +916,6 @@ class Portal(DBPortal, BasePortal):
 
             if content:
                 if message.sticker.attachment.blurhash:
-                    content.info["blurhash"] = message.sticker.attachment.blurhash
                     content.info["xyz.amorgan.blurhash"] = message.sticker.attachment.blurhash
                 await self._add_sticker_meta(message.sticker, content)
                 if reply_to and not message.body:
@@ -1039,7 +1038,6 @@ class Portal(DBPortal, BasePortal):
             else:
                 attachment.custom_filename += mimetypes.guess_extension(info.mimetype) or ""
         if attachment.blurhash:
-            info["blurhash"] = attachment.blurhash
             info["xyz.amorgan.blurhash"] = attachment.blurhash
         content = MediaMessageEventContent(
             msgtype=msgtype, info=info, body=attachment.custom_filename


### PR DESCRIPTION
According to the blurhash [proposal](https://github.com/matrix-org/matrix-spec-proposals/blob/anoa/blurhash/proposals/2448-blurhash-for-media.md):
> Implementations wishing to add
> this before this MSC is merged can do so with the following: The
> blurhash key in any events, request or response bodies should be
> replaced with xyz.amorgan.blurhash.

The current implementation of mautrix-signal sets both `blurhash` and
`xyz.amorgan.blurhash`, which breaks for example the deserialization of
such events in [Ruma](https://github.com/ruma/ruma). Ruma handles `xyz.amorgan.blurhash` as
`blurhash`, and when there's also a `blurhash` key present, it fails to
deserialize the event with "duplicate field" error.

This commit fixes the issue by just setting the `xyz.amorgan.blurhash`
key, as per the instructions in the proposal.