### PR TITLE
Bridge join rules (both ways)

### DIFF
--- a/mautrix_signal/matrix.py
+++ b/mautrix_signal/matrix.py
@@ -244,6 +244,7 @@ class MatrixHandler(BaseMatrixHandler):
             EventType.ROOM_TOPIC,
             EventType.ROOM_AVATAR,
             EventType.ROOM_POWER_LEVELS,
+            EventType.ROOM_JOIN_RULES,
         ):
             return
 
@@ -262,6 +263,8 @@ class MatrixHandler(BaseMatrixHandler):
             await portal.handle_matrix_topic(user, evt.content.topic)
         elif evt.type == EventType.ROOM_POWER_LEVELS:
             await portal.handle_matrix_power_level(user, evt.content, evt.unsigned.prev_content)
+        elif evt.type == EventType.ROOM_JOIN_RULES:
+            await portal.handle_matrix_join_rules(user, evt.content.join_rule)
 
     async def allow_message(self, user: u.User) -> bool:
         return user.relay_whitelisted


### PR DESCRIPTION
This PR bridges join rules from matrix to signal and vice versa.

`restricted` is bridged as `ADMINISTRATOR`, which is the same as for `knock`.
I was considering for a while whether it should be `ANY` (the bridge bot can invite puppets that don't match the restrictions and joining the signal group from matrix will work) or `UNSATISFIABLE` (A matrix user setting the join rules to `restricted` would probably not want random signal users to join if they don't correspond to the restrictions).
I decided that probably emulating `restricted` for the signal side through a relay is the best course of action, because it produces expected behavior on the matrix side and does not cause problems on the signal side. The only downside is that a relay would be required even if only logged-in users are in the room. Auto-setting the room creator or otherwise a signal administrator as the relay might be useful. If there is no signal administrator on matrix, then nobody should be able to set the join rule to `restricted` in the first place.
I think that as soon as there is an admin on matrix, we probably want to treat the room as a plumbed room and the remote platform should not restrict what is possible on matrix - especially considering bridging several remote platforms into the same room.
Most of these are just thoughts for future work though, I'm planning to bridge knocks at some point. Join rules only are of limited use, but a prerequisite.