### PR TITLE
catch ProfileUnavailableError in _update_participants

### DIFF
--- a/mausignald/errors.py
+++ b/mausignald/errors.py
@@ -106,6 +106,10 @@ class UnregisteredUserError(ResponseError):
     pass
 
 
+class ProfileUnavailableError(ResponseError):
+    pass
+
+
 response_error_types = {
     "invalid_request": RequestValidationFailure,
     "TimeoutException": TimeoutException,
@@ -119,6 +123,7 @@ response_error_types = {
     "ScanTimeoutError": ScanTimeoutError,
     "OwnProfileKeyDoesNotExistError": OwnProfileKeyDoesNotExistError,
     "UnregisteredUserError": UnregisteredUserError,
+    "ProfileUnavailableError": ProfileUnavailableError,
     # TODO add rest from https://gitlab.com/signald/signald/-/tree/main/src/main/java/io/finn/signald/clientprotocol/v1/exceptions
 }
 

--- a/mautrix_signal/portal.py
+++ b/mautrix_signal/portal.py
@@ -26,7 +26,12 @@ import os.path
 import pathlib
 import time
 
-from mausignald.errors import AttachmentTooLargeError, NotConnected, RPCError
+from mausignald.errors import (
+    AttachmentTooLargeError,
+    NotConnected,
+    ProfileUnavailableError,
+    RPCError,
+)
 from mausignald.types import (
     AccessControlMode,
     Address,
@@ -1649,7 +1654,10 @@ class Portal(DBPortal, BasePortal):
                 await self.main_intent.invite_user(self.mxid, user.mxid, check_cache=True)
 
             puppet = await p.Puppet.get_by_address(address)
-            await source.sync_contact(address)
+            try:
+                await source.sync_contact(address)
+            except ProfileUnavailableError:
+                self.log.debug(f"Profile of puppet with {address} is unavailable")
             await puppet.intent_for(self).ensure_joined(self.mxid)
             remove_users.discard(puppet.default_mxid)
 
@@ -1660,7 +1668,10 @@ class Portal(DBPortal, BasePortal):
                 await self.main_intent.invite_user(self.mxid, user.mxid, check_cache=True)
 
             puppet = await p.Puppet.get_by_address(address)
-            await source.sync_contact(address)
+            try:
+                await source.sync_contact(address)
+            except ProfileUnavailableError:
+                self.log.debug(f"Profile of puppet with {address} is unavailable")
             await self.main_intent.invite_user(
                 self.mxid, puppet.intent_for(self).mxid, check_cache=True
             )


### PR DESCRIPTION
currently, a ProfileUnavailableError will cause _update_participants to fail and groups won't update properly. This PR catches the Error so the remainder of _update_participants can execute.