### PR TITLE
bridge kick/invite/leave from Signal to Matrix with correct sender

### DIFF
--- a/mautrix_signal/portal.py
+++ b/mautrix_signal/portal.py
@@ -1153,7 +1153,7 @@ class Portal(DBPortal, BasePortal):
 
     async def handle_signal_kicked(self, user: u.User, sender: p.Puppet) -> None:
         self.log.debug(f"{user.mxid} was kicked by {sender.number} from {self.mxid}")
-        await self.main_intent.kick_user(self.mxid, user.mxid, f"{sender.name} kicked you")
+        await self._kick_with_puppet(user, sender)
 
     @staticmethod
     async def _make_media_content(
@@ -1498,7 +1498,7 @@ class Portal(DBPortal, BasePortal):
         else:
             raise ValueError(f"Unexpected type for group update_info: {type(info)}")
         changed = await self._update_avatar(info, sender) or changed
-        await self._update_participants(source, info)
+        await self._update_participants(source, info, sender)
         try:
             await self._update_power_levels(info)
         except Exception:
@@ -1628,7 +1628,9 @@ class Portal(DBPortal, BasePortal):
             self.avatar_set = False
         return True
 
-    async def _update_participants(self, source: u.User, info: ChatInfo) -> None:
+    async def _update_participants(
+        self, source: u.User, info: ChatInfo, sender: p.Puppet | None = None
+    ) -> None:
         if not self.mxid or not isinstance(info, (Group, GroupV2)):
             return
 
@@ -1646,10 +1648,16 @@ class Portal(DBPortal, BasePortal):
             user = await u.User.get_by_address(address)
             if user:
                 remove_users.discard(user.mxid)
-                await self.main_intent.invite_user(self.mxid, user.mxid, check_cache=True)
+                await self._try_with_puppet(
+                    lambda i: i.invite_user(self.mxid, user.mxid, check_cache=True), puppet=sender
+                )
 
             puppet = await p.Puppet.get_by_address(address)
             await source.sync_contact(address)
+            await self._try_with_puppet(
+                lambda i: i.invite_user(self.mxid, puppet.intent_for(self).mxid, check_cache=True),
+                puppet=sender,
+            )
             await puppet.intent_for(self).ensure_joined(self.mxid)
             remove_users.discard(puppet.default_mxid)
 
@@ -1657,25 +1665,41 @@ class Portal(DBPortal, BasePortal):
             user = await u.User.get_by_address(address)
             if user:
                 remove_users.discard(user.mxid)
-                await self.main_intent.invite_user(self.mxid, user.mxid, check_cache=True)
+                await self._try_with_puppet(
+                    lambda i: i.invite_user(self.mxid, user.mxid, check_cache=True), puppet=sender
+                )
 
             puppet = await p.Puppet.get_by_address(address)
             await source.sync_contact(address)
-            await self.main_intent.invite_user(
-                self.mxid, puppet.intent_for(self).mxid, check_cache=True
+            await self._try_with_puppet(
+                lambda i: i.invite_user(self.mxid, puppet.intent_for(self).mxid, check_cache=True),
+                puppet=sender,
             )
             remove_users.discard(puppet.default_mxid)
 
         for mxid in remove_users:
+            user = await u.User.get_by_mxid(mxid, create=False)
+            if user and await user.is_logged_in():
+                await self._kick_with_puppet(user, sender)
             puppet = await p.Puppet.get_by_mxid(mxid, create=False)
             if puppet:
-                await puppet.default_mxid_intent.leave_room(self.mxid)
-            else:
-                user = await u.User.get_by_mxid(mxid, create=False)
-                if user and await user.is_logged_in():
-                    await self.main_intent.kick_user(
-                        self.mxid, user.mxid, "You are not a member of this Signal group"
-                    )
+                if puppet == sender:
+                    await puppet.intent_for(self).leave_room(self.mxid)
+                else:
+                    await self._kick_with_puppet(puppet, sender)
+
+    async def _kick_with_puppet(
+        self, user: p.Puppet | u.User, sender: p.Puppet | None = None
+    ) -> None:
+        if sender:
+            try:
+                await sender.intent_for(self).kick_user(self.mxid, user.mxid)
+            except:
+                await self.main_intent.kick_user(self.mxid, user.mxid, f"kicked by {sender.name}")
+        else:
+            await self.main_intent.kick_user(
+                self.mxid, user.mxid, "Not a member of this Signal group"
+            )
 
     async def _update_power_levels(self, info: ChatInfo) -> None:
         if not self.mxid:

--- a/mautrix_signal/portal.py
+++ b/mautrix_signal/portal.py
@@ -1705,7 +1705,7 @@ class Portal(DBPortal, BasePortal):
         if sender:
             try:
                 await sender.intent_for(self).kick_user(self.mxid, user.mxid)
-            except:
+            except (MForbidden, IntentError):
                 await self.main_intent.kick_user(self.mxid, user.mxid, f"kicked by {sender.name}")
         else:
             await self.main_intent.kick_user(


### PR DESCRIPTION
This PR bridges kick/invite with correct metadata
- changes detected by sync/restart are performed by the bridge bot. Otherwise:
- invites are always performed by the correct puppet
- kicks are preferably performed by the correct puppet. If the user/puppet that is being kicked is an `ADMINISTRATOR`, then they can be kicked on Signal, but kicking users with equal power level is not permitted on matrix. In that case the kick is performed by bridge bot, with the sender given in the reason.
- The reason for kicking is now formulated to address everyone, not just the person being kicked (previously: "xyz kicked you", "you are not a member..."
- Only leaves are bridged as leaves.

If `levels.invite`>50, then signal `ADMINISTRATOR`s are still able to invite users, the invite is then bridged by the bot, but no reason is provided, so the inviter is unknown on the matrix side. Currently, `levels.invite` is forced to 50 or 0, so this shouldn't currently be an issue, but we should consider respecting the setting being changed in matrix for plumbed rooms.