### PR TITLE
Bridge join via invite link to knock (Signal->Matrix), bridge ban/unban (Signal-> Matrix)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -45,11 +45,12 @@
     * [ ] Real time
       * [x] Groups
       * [ ] Users
-  * [ ] Membership actions
+  * [x] Membership actions
     * [x] Join
     * [x] Invite
-    * [ ] Request join (via invite link)
-    * [x] Kick / leave
+    * [x] Request join (via invite link, requires a client that supports knocks)
+    * [x] Leave
+    * [x] Kick/Ban/Unban
   * [x] Group permissions
   * [x] Typing notifications
   * [x] Read receipts

--- a/mausignald/signald.py
+++ b/mausignald/signald.py
@@ -369,6 +369,28 @@ class SignaldClient(SignaldRPCClient):
         )
         return GroupV2.deserialize(resp)
 
+    async def approve_membership(
+        self, username: str, group_id: GroupID, members: list[Address]
+    ) -> GroupV2:
+        serialized_members = [member.serialize() for member in (members or [])]
+        resp = await self.request_v1(
+            "approve_membership", account=username, groupID=group_id, members=serialized_members
+        )
+        return GroupV2.deserialize(resp)
+
+    async def refuse_membership(
+        self, username: str, group_id: GroupID, members: list[Address], also_ban: bool = False
+    ) -> GroupV2:
+        serialized_members = [member.serialize() for member in (members or [])]
+        resp = await self.request_v1(
+            "refuse_membership",
+            account=username,
+            group_id=group_id,
+            members=serialized_members,
+            also_ban=also_ban,
+        )
+        return GroupV2.deserialize(resp)
+
     async def update_group(
         self,
         username: str,


### PR DESCRIPTION
Joining via invite link if the link policy is `ADMINISTRATOR` and the join_rule is `knock` will trigger a knock. The knock may then be accepted, which causes the signal user to be accepted into the group and join the matrix room.
- I was unable to test rejecting knocks, because I don't have a client that supports rejecting knocks. I'm quite confident that the code is correct though.
- requires https://github.com/mautrix/python/pull/105 (I see it was just merged)
- this PR only really makes sense with https://github.com/mautrix/signal/pull/268, to ensure that link policy and join_rule match, but it shouldn't cause any issues if they don't. Join requests just won't work in that case.

One problem is that join requests are not pushed as a message on signal, but have to be fetched by the client. The signal app triggers a group update whenever the group is opened in the app, mautrix-signal only does so upon sync or if a message on the group comes in that has a new revision. I don't think there is a way to detect whether a user is looking at a particular room, in order to replicate the behavior on matrix. That means that unless the user runs `sync` by hand, join requests could be received much later than they were sent and there's most likely nothing we can do about it, other than having a PR accepted at signal. Thanks to @thefinn93 for figuring that out.

edit: I also added a small fix to the ban and unban mausignald functions. They only return GroupV2, because Group version 1 doesn't support bans.