### PR TITLE
set Signal user's phone number as topic in DMs

### DIFF
--- a/mautrix_signal/portal.py
+++ b/mautrix_signal/portal.py
@@ -1515,11 +1515,14 @@ class Portal(DBPortal, BasePortal):
         if self.is_direct:
             if not isinstance(info, (Profile, Address)):
                 raise ValueError(f"Unexpected type for direct chat update_info: {type(info)}")
-            if not self.name:
+            if not self.name or not self.topic:
                 puppet = await self.get_dm_puppet()
                 if not puppet.name:
                     await puppet.update_info(info, source)
                 self.name = puppet.name
+                if puppet.number and not self.topic:
+                    self.topic = puppet.fmt_phone(puppet.number)
+                    self.update_puppet_number(self.topic)
             return
 
         if isinstance(info, GroupV2ID):
@@ -1591,6 +1594,17 @@ class Portal(DBPortal, BasePortal):
             puppet = await self.get_dm_puppet()
         await self.update_puppet_name(puppet.name, save=False)
         await self.update_puppet_avatar(puppet.avatar_hash, puppet.avatar_url, save=False)
+        if puppet.number:
+            await self.update_puppet_number(puppet.fmt_phone(puppet.number), save=False)
+
+    async def update_puppet_number(self, number: str, save: bool = True) -> None:
+        if not self.encrypted and not self.private_chat_portal_meta:
+            return
+
+        changed = await self._update_topic(number)
+        if changed and save:
+            await self.update_bridge_info()
+            await self.update()
 
     async def update_puppet_avatar(
         self, new_hash: str, avatar_url: ContentURI, save: bool = True


### PR DESCRIPTION
This sets the topic of a DM to the Signal user's phone number.
It also handles a change of phone number (since apparently signal is able to do that)