### PR TITLE
add invite command, enable relay for invites

### DIFF
--- a/mautrix_signal/commands/signal.py
+++ b/mautrix_signal/commands/signal.py
@@ -23,6 +23,7 @@ import json
 from mausignald.errors import UnknownIdentityKey, UnregisteredUserError
 from mausignald.types import Address, GroupID, TrustLevel
 from mautrix.appservice import IntentAPI
+from mautrix.bridge import RejectMatrixInvite
 from mautrix.bridge.commands import SECTION_ADMIN, HelpSection, command_handler
 from mautrix.types import (
     ContentURI,
@@ -586,3 +587,30 @@ async def warn_missing_power(levels: PowerLevelStateEventContent, evt: CommandEv
         or levels.events[EventType.ROOM_TOPIC] >= 50
     ):
         await evt.reply(meta_power_warning)
+
+
+@command_handler(
+    needs_auth=False,
+    management_only=False,
+    help_section=SECTION_SIGNAL,
+    help_text="Invite a Signal user by phone number",
+    help_args="<_phone_>",
+)
+async def invite(evt: CommandEvent) -> EventID:
+    if not evt.is_portal:
+        return await evt.reply("This is not a portal room.")
+    else:
+        portal = evt.portal
+    puppet = await _get_puppet_from_cmd(evt)
+    if not puppet:
+        return
+    levels = await portal.main_intent.get_power_levels(portal.mxid)
+    if levels.get_user_level(puppet.mxid) < levels.invite:
+        return await evt.reply("You do not have permissions to invite users to this room")
+
+    try:
+        info = await portal.handle_matrix_invite(evt.sender, puppet)
+        sender, is_relay = await portal.get_relay_sender(evt.sender, "updating info")
+        await portal.update_info(sender, info)
+    except RejectMatrixInvite as e:
+        return await evt.reply(f"Failed to invite {puppet.name}: {e}")

--- a/mautrix_signal/config.py
+++ b/mautrix_signal/config.py
@@ -94,6 +94,7 @@ class Config(BaseBridgeConfig):
         copy("bridge.relay.enabled")
         copy_dict("bridge.relay.message_formats")
         copy("bridge.relay.relaybot")
+        copy("bridge.relay.invite")
         copy("bridge.bridge_matrix_leave")
         copy("bridge.location_format")
 

--- a/mautrix_signal/example-config.yaml
+++ b/mautrix_signal/example-config.yaml
@@ -307,6 +307,8 @@ bridge:
         # and double puppeting working to auto-accept invites. When this user is invited to a room
         # it will automatically be set as the relay user. May be overridden with `set-relay` or `unset-relay`
         relaybot: '@relaybot:example.com'
+        # Whether or not invites from non-logged-in users should be relayed
+        invite: true
 
     # Format for generating URLs from location messages for sending to Signal
     # Google Maps: 'https://www.google.com/maps/place/{lat},{long}'


### PR DESCRIPTION
Invite a user by typing `!signal invite <phone>` in a bridged room.
Since this is primarily intended for rooms bridged across several platforms for a user of another platform to invite a signal user, I also added relay support for invites. Relaying invites can be disabled in the config. I made the default `true`, because I believe this is expected functionality. In particular if a non-logged-in user invites a logged-in-user, they don't expect them to be kicked by the bridge bot on the next sync.