### PR TITLE
Bridge Matrix -> Signal location

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -10,7 +10,7 @@
       * [x] Audio files
       * [x] Files
       * [x] Gifs
-      * [ ] Locations
+      * [x] Locations
       * [ ] Stickers
   * [x] Message reactions
   * [x] Message redactions

--- a/mautrix_signal/config.py
+++ b/mautrix_signal/config.py
@@ -101,6 +101,7 @@ class Config(BaseBridgeConfig):
         copy("bridge.relay.enabled")
         copy_dict("bridge.relay.message_formats")
         copy("bridge.bridge_matrix_leave")
+        copy("bridge.location_format")
 
     def _get_permissions(self, key: str) -> Permissions:
         level = self["bridge.permissions"].get(key, "")

--- a/mautrix_signal/example-config.yaml
+++ b/mautrix_signal/example-config.yaml
@@ -297,6 +297,11 @@ bridge:
             m.video: '$sender_displayname sent a video'
             m.location: '$sender_displayname sent a location'
 
+    # Format for generting URLs from location messages for sending to Signal
+    # Google Maps: 'https://www.google.com/maps/place/$lat,$long'
+    # OpenStreepMap: 'https://www.openstreetmap.org/?mlat=$lat&mlon=$long'
+    location_format: 'https://www.google.com/maps/place/$lat,$long'
+
 # Python logging configuration.
 #
 # See section 16.7.2 of the Python documentation for more info:


### PR DESCRIPTION
Converts an m.location event to a map link in order to bridge it to signal. Let's you choose the map provider via config setting.
I ran into a bit of a problem with the different fields that provide additional information. `content.body` is supposed to be able to contain a description. Element just copies the `content.geo_uri` field there, which isn't adding anything of value, so it shouldn't be printed. `content.body` also contains relay sender information after the relay format is applied, so I can't exclude the field. I opted for removing the contents of `geo_uri` from `body` before prepending it, since that seemed to be the solution with the least amount of change.

This doesn't include msc3488. I'm not really sure how to account for that because I still need `body` in relay mode. But maybe we can worry about that when extensible events are out, since those would probably require changes to `Portal.apply_relay_message_format` anyway.