### PR TITLE
add relaybot config option and auto-set relay for relaybot

### DIFF
--- a/mautrix_signal/config.py
+++ b/mautrix_signal/config.py
@@ -101,6 +101,7 @@ class Config(BaseBridgeConfig):
 
         copy("bridge.relay.enabled")
         copy_dict("bridge.relay.message_formats")
+        copy("bridge.relay.relaybot")
         copy("bridge.bridge_matrix_leave")
         copy("bridge.location_format")
 

--- a/mautrix_signal/example-config.yaml
+++ b/mautrix_signal/example-config.yaml
@@ -299,6 +299,10 @@ bridge:
             m.audio: '$sender_displayname sent an audio file'
             m.video: '$sender_displayname sent a video'
             m.location: '$sender_displayname sent a location'
+        # Specify a dedicated relay account. Must be a regular matrix account logged into this bridge
+        # and double puppeting working to auto-accept invites. When this user is invited to a room
+        # it will automatically be set as the relay user. May be overridden with `set-relay` or `unset-relay`
+        relaybot: '@relaybot:example.com'
 
     # Format for generting URLs from location messages for sending to Signal
     # Google Maps: 'https://www.google.com/maps/place/{lat},{long}'

--- a/mautrix_signal/portal.py
+++ b/mautrix_signal/portal.py
@@ -863,6 +863,19 @@ class Portal(DBPortal, BasePortal):
             )
         except RPCError as e:
             raise RejectMatrixInvite(str(e)) from e
+        if user.mxid == self.config["bridge.relay.relaybot"]:
+            if not self.config["bridge.relay.enabled"]:
+                await self.main_intent.send_notice(
+                    self.mxid, "Relay mode is not enabled in this instance of the bridge."
+                )
+            else:
+                await self.set_relay_user(user)
+                await self.main_intent.send_notice(
+                    self.mxid,
+                    "Messages from non-logged-in users in this room will now be bridged "
+                    "through the relaybot's Signal account.",
+                )
+
         power_levels = await self.main_intent.get_power_levels(self.mxid)
         invitee_pl = power_levels.get_user_level(user.mxid)
         if invitee_pl >= 50:

--- a/mautrix_signal/portal.py
+++ b/mautrix_signal/portal.py
@@ -863,7 +863,7 @@ class Portal(DBPortal, BasePortal):
             )
         except RPCError as e:
             raise RejectMatrixInvite(str(e)) from e
-        if user.mxid == self.config["bridge.relay.relaybot"]:
+        if user.mxid == self.config["bridge.relay.relaybot"] != "@relaybot:example.com":
             if not self.config["bridge.relay.enabled"]:
                 await self.main_intent.send_notice(
                     self.mxid, "Relay mode is not enabled in this instance of the bridge."


### PR DESCRIPTION
This PR allows users to set a dedicated relaybot user. When the relaybot is invited, it will automatically be set as the relay. This way, users no longer need to log in with the relaybot account to run set-relay manually. The relaybot can be shared between users more easily.