### PR TITLE
Add commands get-timer and set-timer

### DIFF
--- a/mausignald/signald.py
+++ b/mausignald/signald.py
@@ -510,3 +510,25 @@ class SignaldClient(SignaldRPCClient):
             "resolve_address", partial=Address(number=number).serialize(), account=username
         )
         return Address.deserialize(resp).uuid
+
+    async def set_expiration(
+        self,
+        username: str,
+        expiration: int,
+        chat_id: Address | GroupID,
+    ) -> SendMessageResponse:
+        if isinstance(chat_id, Address):
+            resp = await self.request_v1(
+                "set_expiration",
+                account=username,
+                address=chat_id.serialize(),
+                expiration=expiration,
+            )
+        else:
+            resp = await self.request_v1(
+                "set_expiration",
+                account=username,
+                expiration=expiration,
+                group=chat_id,
+            )
+        return SendMessageResponse.deserialize(resp)

--- a/mautrix_signal/portal.py
+++ b/mautrix_signal/portal.py
@@ -1862,7 +1862,11 @@ class Portal(DBPortal, BasePortal):
             await self.update_bridge_info()
             await self.update()
 
-    async def update_expires_in_seconds(self, sender: p.Puppet, expires_in_seconds: int) -> None:
+    async def update_expires_in_seconds(
+        self,
+        sender: p.Puppet | None,
+        expires_in_seconds: int,
+    ) -> None:
         if expires_in_seconds == 0:
             expires_in_seconds = None
         if self.expiration_time == expires_in_seconds:
@@ -1872,6 +1876,8 @@ class Portal(DBPortal, BasePortal):
         self.expiration_time = expires_in_seconds
         await self.update()
 
+        if sender is None:
+            return
         time_str = "Off" if expires_in_seconds is None else format_duration(expires_in_seconds)
         body = f"Set the disappearing message timer to {time_str}"
         content = TextMessageEventContent(msgtype=MessageType.NOTICE, body=body)


### PR DESCRIPTION
This commands are used to get or set the expiration timer for disappearing messages in both, direct and group chats.