### PR TITLE
AND-4424: don't show error messages on decryption failure for IMPLICIT messages

### DIFF
--- a/mautrix_signal/signal.py
+++ b/mautrix_signal/signal.py
@@ -129,6 +129,9 @@ class SignalHandler(SignaldClient):
             f"{err.data.message}"
         )
 
+        if err.data.content_hint == 2:
+            return
+
         sender = await pu.Puppet.get_by_address(
             Address.parse(err.data.sender), resolve_via=err.account
         )


### PR DESCRIPTION
it looks like these are things like typing notifications, and read receipts