### PR TITLE
Add ProofRequiredError Exception and submit-challenge command

### DIFF
--- a/mausignald/errors.py
+++ b/mausignald/errors.py
@@ -7,6 +7,8 @@ from __future__ import annotations
 
 from typing import Any
 
+from mautrix.util.format_duration import format_duration
+
 
 class RPCError(Exception):
     pass
@@ -123,11 +125,12 @@ class ProofRequiredError(ResponseError):
         self.options = data.get("options")
         self.retry_after = data.get("retry_after")
         self.token = data.get("token")
-        message = (
-            f"You have been rate-limited by Signal. Try again in {self.retry_after} "
-            "seconds or complete a captcha challenge using the `submit-challenge` command. "
-            "A captcha may be obtained at https://signalcaptchas.org/challenge/generate.html"
-        )
+        message = "You have been rate limited by Signal."
+        if isinstance(self.retry_after, (int, float)):
+            message += (
+                f" Try again in {format_duration(int(self.retry_after))} "
+                "or complete a captcha challenge using the `submit-challenge` command."
+            )
         super().__init__(data, message_override=message)
 
 

--- a/mausignald/errors.py
+++ b/mausignald/errors.py
@@ -118,6 +118,19 @@ class GroupPatchNotAcceptedError(ResponseError):
     pass
 
 
+class ProofRequiredError(ResponseError):
+    def __init__(self, data: dict[str, Any]) -> None:
+        self.options = data.get("options")
+        self.retry_after = data.get("retry_after")
+        self.token = data.get("token")
+        message = (
+            f"You have been rate-limited by Signal. Try again in {self.retry_after} "
+            "seconds or complete a captcha challenge using the `submit-challenge` command. "
+            "A captcha may be obtained at https://signalcaptchas.org/challenge/generate.html"
+        )
+        super().__init__(data, message_override=message)
+
+
 response_error_types = {
     "invalid_request": RequestValidationFailure,
     "TimeoutException": TimeoutException,
@@ -134,6 +147,7 @@ response_error_types = {
     "ProfileUnavailableError": ProfileUnavailableError,
     "NoSuchAccountError": NoSuchAccountError,
     "GroupPatchNotAcceptedError": GroupPatchNotAcceptedError,
+    "ProofRequiredError": ProofRequiredError,
     # TODO add rest from https://gitlab.com/signald/signald/-/tree/main/src/main/java/io/finn/signald/clientprotocol/v1/exceptions
 }
 

--- a/mausignald/signald.py
+++ b/mausignald/signald.py
@@ -548,3 +548,10 @@ class SignaldClient(SignaldRPCClient):
             "resolve_address", partial=Address(number=number).serialize(), account=username
         )
         return Address.deserialize(resp).uuid
+
+    async def submit_challenge(
+        self, username: str, captcha_token: str | None, challenge: str | None
+    ) -> None:
+        await self.request_v1(
+            "submit_challenge", account=username, captcha_token=captcha_token, challenge=challenge
+        )

--- a/mautrix_signal/commands/signal.py
+++ b/mautrix_signal/commands/signal.py
@@ -519,7 +519,7 @@ async def confirm_bridge(evt: CommandEvent) -> EventID | None:
 )
 async def submit_challenge(evt: CommandEvent) -> None:
     if len(evt.args == 0):
-        await evt.reply("**Usage:** `$cmdprefix+sp captcha-challenge <captcha-token>`")
+        await evt.reply("**Usage:** `$cmdprefix+sp submit-challenge <captcha token>`")
         return
     challenge_token = evt.sender.challenge_token
     captcha_token = evt.args[0]
@@ -528,16 +528,14 @@ async def submit_challenge(evt: CommandEvent) -> None:
             "No open challenge found. If the bridge was restarted, try"
             "triggering another ProofRequiredError"
         )
-    evt.log.debug(f"submitting challenge for token {challenge_token}")
+    evt.log.debug(f"Submitting challenge for token {challenge_token}")
     try:
         await evt.bridge.signal.submit_challenge(
             evt.sender.username, captcha_token=evt.args[0], challenge=challenge_token
         )
     except Exception as e:
-        await evt.reply(f"failed to submit captcha challenge: {e}")
-        return
-    await evt.reply("Captcha challenge submitted successfully")
-    return
+        return await evt.reply(f"Failed to submit captcha challenge: {e}")
+    return await evt.reply("Captcha challenge submitted successfully")
 
 
 async def _locked_confirm_bridge(

--- a/mautrix_signal/portal.py
+++ b/mautrix_signal/portal.py
@@ -31,6 +31,7 @@ from mausignald.errors import (
     GroupPatchNotAcceptedError,
     NotConnected,
     ProfileUnavailableError,
+    ProofRequiredError,
     RPCError,
 )
 from mausignald.types import (
@@ -328,6 +329,8 @@ class Portal(DBPortal, BasePortal):
                 status, event_id, self.mxid, EventType.ROOM_MESSAGE, message.msgtype, error=e
             )
             await sender.handle_auth_failure(e)
+            if isinstance(e, ProofRequiredError):
+                sender.challenge_token = e.token
             await self._send_error_notice("message", e)
             background_task.create(self._send_message_status(event_id, e))
 

--- a/mautrix_signal/user.py
+++ b/mautrix_signal/user.py
@@ -77,6 +77,8 @@ class User(DBUser, BaseUser):
     _websocket_connection_state: BridgeStateEvent | None
     _latest_non_transient_bridge_state: datetime | None
 
+    challenge_token: str | None
+
     def __init__(
         self,
         mxid: UserID,

--- a/mautrix_signal/user.py
+++ b/mautrix_signal/user.py
@@ -94,6 +94,7 @@ class User(DBUser, BaseUser):
         self._state_id = self.username
         self._websocket_connection_state = None
         self._latest_non_transient_bridge_state = None
+        self.challenge_token = None
         perms = self.config.get_permissions(mxid)
         self.relay_whitelisted, self.is_whitelisted, self.is_admin, self.permission_level = perms
 


### PR DESCRIPTION
This is still entirely untested since I would need a ProofRequiredError to do so. I am not currently commited enough to try and trigger one for my Signal account, but anyone who has one, please try. Or if you find obvious mistakes without testing, let me know.

I've noticed that ProofRequiredError rarely comes in the SendMessageResult, but usually as a ResponseError, so I created another ProofRequiredException in errors.py. I didn't know how to reconcile the two, since SendMessageResult probably wouldn't work with an Exception instead of a SerializableAttrs, but I also needed to inherit from ResponseError.

When portal.handle_matrix_message() encounters a ProofRequiredError, it should store a token in the respective user, so the user won't have to copy&paste that. Since tokens are temporary in nature and I don't know how to work with databases, it's not stored in the database. I suppose that's fine.

The user can then use the submit-challenge command with just a captcha token to complete the challenge. I currently don't handle PUSH_CHALLENGE. So far, I have only encountered RECAPTCHA, I would prefer to first handle that and then worry about the other (probably just two lines, but still).