### PR TITLE
Add additional comment for clarification on domain setting

### DIFF
--- a/mautrix_signal/example-config.yaml
+++ b/mautrix_signal/example-config.yaml
@@ -1,9 +1,10 @@
 # Homeserver details
 homeserver:
     # The address that this appservice can use to connect to the homeserver.
-    address: https://example.com
+    address: https://synapse.example.com
     # The domain of the homeserver (for MXIDs, etc).
-    domain: example.com
+    # This should be the exact same value as `server_name` in homeserver.yaml
+    domain: synapse.example.com
     # Whether or not to verify the SSL certificate of the homeserver.
     # Only applies if address starts with https://
     verify_ssl: true


### PR DESCRIPTION
A common issue reported here and in support requests is the the failed `/registration`. It is currently covered in the Troubleshooting and FAQ here: https://docs.mau.fi/bridges/general/troubleshooting.html

For new users, the problem likely stems from the use of the term `domain` instead of `server_name`. Additionally, using `example.com` instead of something like `synapse.example.com` or `matrix.example.com` could be leading to more confusion since many people aren't setting up a matrix instance on their root domain.

This PR updates the example config to include the hostname with the domain, and adds an additional comment that should hopefully eliminate any future confusion.