### PR TITLE
Add personal space for signal chats

### DIFF
--- a/mautrix_signal/config.py
+++ b/mautrix_signal/config.py
@@ -45,6 +45,7 @@ class Config(BaseBridgeConfig):
         copy("signal.remove_file_after_handling")
         copy("signal.registration_enabled")
         copy("signal.enable_disappearing_messages_in_groups")
+        copy("signal.space_per_user")
 
         copy("metrics.enabled")
         copy("metrics.listen_port")

--- a/mautrix_signal/config.py
+++ b/mautrix_signal/config.py
@@ -45,13 +45,13 @@ class Config(BaseBridgeConfig):
         copy("signal.remove_file_after_handling")
         copy("signal.registration_enabled")
         copy("signal.enable_disappearing_messages_in_groups")
-        copy("signal.space_per_user")
 
         copy("metrics.enabled")
         copy("metrics.listen_port")
 
         copy("bridge.username_template")
         copy("bridge.displayname_template")
+        copy("bridge.personal_filtering_spaces")
         if self["bridge.allow_contact_list_name_updates"]:
             base["bridge.contact_list_names"] = "allow"
         else:

--- a/mautrix_signal/db/upgrade/__init__.py
+++ b/mautrix_signal/db/upgrade/__init__.py
@@ -14,4 +14,5 @@ from . import (
     v09_group_topic,
     v10_puppet_name_quality,
     v11_drop_number_support,
+    v12_space_per_user,
 )

--- a/mautrix_signal/db/upgrade/v00_latest_revision.py
+++ b/mautrix_signal/db/upgrade/v00_latest_revision.py
@@ -18,7 +18,7 @@ from mautrix.util.async_db import Connection
 from . import upgrade_table
 
 
-@upgrade_table.register(description="Initial revision", upgrades_to=11)
+@upgrade_table.register(description="Initial revision", upgrades_to=12)
 async def upgrade_latest(conn: Connection) -> None:
     await conn.execute(
         """CREATE TABLE portal (
@@ -44,7 +44,8 @@ async def upgrade_latest(conn: Connection) -> None:
             mxid        TEXT PRIMARY KEY,
             username    TEXT,
             uuid        UUID,
-            notice_room TEXT
+            notice_room TEXT,
+            space_room TEXT NOT NULL DEFAULT ''
         )"""
     )
     await conn.execute(

--- a/mautrix_signal/db/upgrade/v12_space_per_user.py
+++ b/mautrix_signal/db/upgrade/v12_space_per_user.py
@@ -19,5 +19,5 @@ from . import upgrade_table
 
 
 @upgrade_table.register(description="Store space in user table")
-async def upgrade_v10(conn: Connection) -> None:
+async def upgrade_v12(conn: Connection) -> None:
     await conn.execute("ALTER TABLE user ADD COLUMN space_room TEXT NOT NULL DEFAULT ''")

--- a/mautrix_signal/db/upgrade/v12_space_per_user.py
+++ b/mautrix_signal/db/upgrade/v12_space_per_user.py
@@ -1,0 +1,23 @@
+# mautrix-signal - A Matrix-Signal puppeting bridge
+# Copyright (C) 2022 Tulir Asokan
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+from mautrix.util.async_db import Connection
+
+from . import upgrade_table
+
+
+@upgrade_table.register(description="Store space in user table")
+async def upgrade_v10(conn: Connection) -> None:
+    await conn.execute("ALTER TABLE user ADD COLUMN space_room TEXT NOT NULL DEFAULT ''")

--- a/mautrix_signal/db/user.py
+++ b/mautrix_signal/db/user.py
@@ -38,11 +38,15 @@ class User:
 
     async def insert(self) -> None:
         q = 'INSERT INTO "user" (mxid, username, uuid, notice_room, space_room) VALUES ($1, $2, $3, $4, $5)'
-        await self.db.execute(q, self.mxid, self.username, self.uuid, self.notice_room, self.space_room)
+        await self.db.execute(
+            q, self.mxid, self.username, self.uuid, self.notice_room, self.space_room
+        )
 
     async def update(self) -> None:
         q = 'UPDATE "user" SET username=$1, uuid=$2, notice_room=$3, space_room=$4 WHERE mxid=$5'
-        await self.db.execute(q, self.username, self.uuid, self.notice_room, self.space_room, self.mxid)
+        await self.db.execute(
+            q, self.username, self.uuid, self.notice_room, self.space_room, self.mxid
+        )
 
     @classmethod
     async def get_by_mxid(cls, mxid: UserID) -> User | None:

--- a/mautrix_signal/db/user.py
+++ b/mautrix_signal/db/user.py
@@ -34,18 +34,19 @@ class User:
     username: str | None
     uuid: UUID | None
     notice_room: RoomID | None
+    space_room: RoomID | None
 
     async def insert(self) -> None:
-        q = 'INSERT INTO "user" (mxid, username, uuid, notice_room) VALUES ($1, $2, $3, $4)'
-        await self.db.execute(q, self.mxid, self.username, self.uuid, self.notice_room)
+        q = 'INSERT INTO "user" (mxid, username, uuid, notice_room, space_room) VALUES ($1, $2, $3, $4, $5)'
+        await self.db.execute(q, self.mxid, self.username, self.uuid, self.notice_room, self.space_room)
 
     async def update(self) -> None:
-        q = 'UPDATE "user" SET username=$1, uuid=$2, notice_room=$3 WHERE mxid=$4'
-        await self.db.execute(q, self.username, self.uuid, self.notice_room, self.mxid)
+        q = 'UPDATE "user" SET username=$1, uuid=$2, notice_room=$3, space_room=$4 WHERE mxid=$5'
+        await self.db.execute(q, self.username, self.uuid, self.notice_room, self.space_room, self.mxid)
 
     @classmethod
     async def get_by_mxid(cls, mxid: UserID) -> User | None:
-        q = 'SELECT mxid, username, uuid, notice_room FROM "user" WHERE mxid=$1'
+        q = 'SELECT mxid, username, uuid, notice_room, space_room FROM "user" WHERE mxid=$1'
         row = await cls.db.fetchrow(q, mxid)
         if not row:
             return None
@@ -53,7 +54,7 @@ class User:
 
     @classmethod
     async def get_by_username(cls, username: str) -> User | None:
-        q = 'SELECT mxid, username, uuid, notice_room FROM "user" WHERE username=$1'
+        q = 'SELECT mxid, username, uuid, notice_room, space_room FROM "user" WHERE username=$1'
         row = await cls.db.fetchrow(q, username)
         if not row:
             return None
@@ -61,7 +62,7 @@ class User:
 
     @classmethod
     async def get_by_uuid(cls, uuid: UUID) -> User | None:
-        q = 'SELECT mxid, username, uuid, notice_room FROM "user" WHERE uuid=$1'
+        q = 'SELECT mxid, username, uuid, notice_room, space_room FROM "user" WHERE uuid=$1'
         row = await cls.db.fetchrow(q, uuid)
         if not row:
             return None
@@ -69,6 +70,6 @@ class User:
 
     @classmethod
     async def all_logged_in(cls) -> list[User]:
-        q = 'SELECT mxid, username, uuid, notice_room FROM "user" WHERE username IS NOT NULL'
+        q = 'SELECT mxid, username, uuid, notice_room, space_room FROM "user" WHERE username IS NOT NULL'
         rows = await cls.db.fetch(q)
         return [cls(**row) for row in rows]

--- a/mautrix_signal/example-config.yaml
+++ b/mautrix_signal/example-config.yaml
@@ -110,6 +110,8 @@ signal:
     # time of the messages will be determined by the first users to read the message, rather
     # than individually. If the bridge has a single user, this can be turned on safely.
     enable_disappearing_messages_in_groups: false
+    # Creates a space for all the rooms bridged
+    space_per_user: false
 
 # Bridge config
 bridge:

--- a/mautrix_signal/example-config.yaml
+++ b/mautrix_signal/example-config.yaml
@@ -110,8 +110,6 @@ signal:
     # time of the messages will be determined by the first users to read the message, rather
     # than individually. If the bridge has a single user, this can be turned on safely.
     enable_disappearing_messages_in_groups: false
-    # Creates a space for all the rooms bridged
-    space_per_user: false
 
 # Bridge config
 bridge:
@@ -123,6 +121,8 @@ bridge:
     # available variable in displayname_preference. The variables in displayname_preference
     # can also be used here directly.
     displayname_template: "{displayname} (Signal)"
+    # Should the bridge create a space for each logged-in user and add bridged rooms to it?
+    personal_filtering_spaces: false
     # Whether or not contact list displaynames should be used.
     # Possible values: disallow, allow, prefer
     #

--- a/mautrix_signal/portal.py
+++ b/mautrix_signal/portal.py
@@ -2519,14 +2519,15 @@ class Portal(DBPortal, BasePortal):
             assert self.az._intent is not None
             assert spaceId is not None
             await self.az._intent.send_state_event(
-                    spaceId,
-                    EventType.SPACE_CHILD,
-                    {"via": [self.config["homeserver.domain"]]},
-                    str(self.mxid)
-                )
+                spaceId,
+                EventType.SPACE_CHILD,
+                {"via": [self.config["homeserver.domain"]]},
+                str(self.mxid),
+            )
             self.log.debug(f"Added room {self.mxid} to user's personal space ({spaceId})")
         except Exception:
             self.log.warning(f"Failed to add chat {self.mxid} to user's personal space.")
+
     # endregion
     # region Database getters
 

--- a/mautrix_signal/portal.py
+++ b/mautrix_signal/portal.py
@@ -2441,9 +2441,9 @@ class Portal(DBPortal, BasePortal):
 
         if self.config["signal.space_per_user"]:
             spaceId = await source.get_space_room()
-            self.log.debug("Adding parent state for new room : %s", spaceId)
+            self.log.debug("Adding parent state for new room: %s", spaceId)
             parentSpaceContent = {}
-            parentSpaceContent["via"] = self.config["homeserver.domain"].split(".")
+            parentSpaceContent["via"] = self.config["homeserver.domain"].split()
             parentSpaceContent["canonical"] = True
             initial_state.append(
                 {
@@ -2530,9 +2530,10 @@ class Portal(DBPortal, BasePortal):
 
     async def _add_to_space(self, spaceId: RoomID, portalId: RoomID | None):
         self.log.debug("Adding room %s to space %s", portalId, spaceId)
+        assert self.az._intent is not None
         parentSpaceContent = {}
-        parentSpaceContent["via"] = self.config["homeserver.domain"].split(".")
-        await self.az._intent.send_state_event(spaceId, EventType.SPACE_CHILD, parentSpaceContent)
+        parentSpaceContent["via"] = self.config["homeserver.domain"].split()
+        await self.az._intent.send_state_event(spaceId, EventType.SPACE_CHILD, parentSpaceContent, portalId)
 
     # endregion
     # region Database getters

--- a/mautrix_signal/portal.py
+++ b/mautrix_signal/portal.py
@@ -2441,6 +2441,7 @@ class Portal(DBPortal, BasePortal):
 
         if self.config["signal.space_per_user"]:
             spaceId = await source.get_space_room()
+            self.log.debug("Adding parent state for new room : %s", spaceId)
             parentSpaceContent = {}
             parentSpaceContent["via"] = self.config["homeserver.domain"].split(".")
             parentSpaceContent["canonical"] = True

--- a/mautrix_signal/user.py
+++ b/mautrix_signal/user.py
@@ -167,15 +167,13 @@ class User(DBUser, BaseUser):
         if not self.space_room:
             self.log.debug("Locking to create space.")
             self._space_room_lock = asyncio.Lock()
-            puppet = await self.get_puppet()
-            main_intent = self.az._intent
             self.log.debug("Inviting user " + self.mxid)
             invites = []
             invites.append(self.mxid)
             self.log.debug("Creating a new space for the user")
             creation_content= {}
             creation_content["type"] = "m.space"
-            spaceId = await main_intent.create_room(
+            spaceId = await self.az._intent.create_room(
                     name="Signal",
                     topic="Signal bridge space",
                     invitees=invites,

--- a/mautrix_signal/user.py
+++ b/mautrix_signal/user.py
@@ -83,7 +83,9 @@ class User(DBUser, BaseUser):
         notice_room: RoomID | None = None,
         space_room: RoomID | None = None,
     ) -> None:
-        super().__init__(mxid=mxid, username=username, uuid=uuid, notice_room=notice_room, space_room=space_room)
+        super().__init__(
+            mxid=mxid, username=username, uuid=uuid, notice_room=notice_room, space_room=space_room
+        )
         BaseUser.__init__(self)
         self._notice_room_lock = asyncio.Lock()
         self._sync_lock = asyncio.Lock()
@@ -177,19 +179,16 @@ class User(DBUser, BaseUser):
             avatar_state_event_content = {"url": self.config["appservice.bot_avatar"]}
             assert self.az._intent is not None
             room = await self.az._intent.create_room(
-                    name="Signal",
-                    topic="Your Signal bridged chats",
-                    invitees=[self.mxid],
-                    visibility=RoomDirectoryVisibility.PRIVATE,
-                    creation_content={"type": "m.space"},
-                    initial_state=[
-                        {
-                            "type": str(EventType.ROOM_AVATAR),
-                            "content": avatar_state_event_content
-                        },
-                    ],
-                    power_level_override={"users": {self.az._intent.mxid: 9001, self.mxid: 50}}
-                )
+                name="Signal",
+                topic="Your Signal bridged chats",
+                invitees=[self.mxid],
+                visibility=RoomDirectoryVisibility.PRIVATE,
+                creation_content={"type": "m.space"},
+                initial_state=[
+                    {"type": str(EventType.ROOM_AVATAR), "content": avatar_state_event_content},
+                ],
+                power_level_override={"users": {self.az._intent.mxid: 9001, self.mxid: 50}},
+            )
             self.space_room = room
             await self.update()
             self.log.debug(f"Created new space {room}")

--- a/mautrix_signal/user.py
+++ b/mautrix_signal/user.py
@@ -80,8 +80,9 @@ class User(DBUser, BaseUser):
         username: str | None = None,
         uuid: UUID | None = None,
         notice_room: RoomID | None = None,
+        space_room: RoomID | None = None,
     ) -> None:
-        super().__init__(mxid=mxid, username=username, uuid=uuid, notice_room=notice_room)
+        super().__init__(mxid=mxid, username=username, uuid=uuid, notice_room=notice_room, space_room=space_room)
         BaseUser.__init__(self)
         self._notice_room_lock = asyncio.Lock()
         self._sync_lock = asyncio.Lock()


### PR DESCRIPTION
As requested in #102:

- Adds a config option to enable personal filtering spaces
- When activated, creating or updating a room will add it to the user's personal space
- Upgrade compatibility by making the sync command add all group and private chats to the space
(Since sync seems to be automatically invoked upon startup, no additional update steps are needed after setting the config option)

Caveats
- The space child event is always sent upon matrix room update, even if the room already belongs to the space
- Rooms are not automatically removed from space upon unbridging (This might be desireable however, since the user will probably want to see archived unbridged chats still belonging to the Signal space - since they are automatically added as a mod to the space, they might remove the chat from it as they please)
