### PR TITLE
don't kick ghost on GroupPatchNotAcceptedError if they are in the signal group

### DIFF
--- a/mausignald/errors.py
+++ b/mausignald/errors.py
@@ -114,6 +114,10 @@ class NoSuchAccountError(ResponseError):
     pass
 
 
+class GroupPatchNotAcceptedError(ResponseError):
+    pass
+
+
 response_error_types = {
     "invalid_request": RequestValidationFailure,
     "TimeoutException": TimeoutException,
@@ -129,6 +133,7 @@ response_error_types = {
     "UnregisteredUserError": UnregisteredUserError,
     "ProfileUnavailableError": ProfileUnavailableError,
     "NoSuchAccountError": NoSuchAccountError,
+    "GroupPatchNotAcceptedError": GroupPatchNotAcceptedError,
     # TODO add rest from https://gitlab.com/signald/signald/-/tree/main/src/main/java/io/finn/signald/clientprotocol/v1/exceptions
 }
 


### PR DESCRIPTION
The bridge used to kick newly invited signal ghosts upon error, even if that error just meant that they already are in the group.

I encountered that error when testing the mautrix-python PR. When the group is created, all users in the room at that moment are added to the group, invites that have gone through on the matrix side at the time of group creation will produce a GroupPatchNotAcceptedError. The bridge should not kick the user if they are confirmed to be in the group.