### PR TITLE
Don't sync groups on periodic syncs if their revision did not change

### DIFF
--- a/mautrix_signal/__main__.py
+++ b/mautrix_signal/__main__.py
@@ -93,7 +93,8 @@ class SignalBridge(Bridge):
                 # Add some randomness to the sync to avoid a thundering herd
                 await asyncio.sleep(uniform(0, SYNC_JITTER))
                 try:
-                    await user.sync(is_startup=hacky_daily_resync and n % 24 == 23)
+                    await user.sync(is_startup=hacky_daily_resync and n % 24 == 23, full=False)
+
                 except asyncio.CancelledError:
                     return
                 except Exception:

--- a/mautrix_signal/portal.py
+++ b/mautrix_signal/portal.py
@@ -2310,6 +2310,7 @@ class Portal(DBPortal, BasePortal):
                 return None
             else:
                 self.log.trace("get_group() returned full info: %s", info)
+        # This should no longer evaluate to True for any code path, keeping it just in case
         if self.mxid:
             await self.update_matrix_room(source, info)
             return self.mxid


### PR DESCRIPTION
Currently, all group info is synced every time. We should not expect there to be anything to sync if the group revision did not change. With this PR, mautrix-signal will not sync groups on regular syncs if their revision did not change. The `sync` command still performs a full sync. For everything else we expect to either get a `GroupChange` or to receive a new revision.
This has two advantages:
- changes made on the matrix side that for some reason didn't propagate to signal won't constantly be overridden by the bridge. This was particularly annoying for rooms with several bridges in it. Obviously, best would be not to have such conflicts in the first place, but blindly overwriting changes seems like the wrong strategy
- it greatly reduces sync time. On my server, a sync from my account went from 8 seconds to 2 seconds to complete. It probably doesn't matter much for my server with 4 bridge users that only syncs every 10 to 20 minutes, but large deployments will benefit.

I made a few more changes: `create_matrix_room()` should no longer be the default if the option is on in the config. If the room exists, `update_matrix_room()` is used. This intuitively made sense to me and also made it easier to check for revision differences earlier in the code.

This PR is a partial fix for #348 