### PR TITLE
Added Preliminary support for MSC2530

### DIFF
--- a/mautrix_signal/config.py
+++ b/mautrix_signal/config.py
@@ -66,6 +66,7 @@ class Config(BaseBridgeConfig):
         copy("bridge.double_puppet_allow_discovery")
         copy("bridge.create_group_on_invite")
         copy("bridge.hacky_contact_name_mixup_detection")
+        copy("bridge.caption_in_message")
         if self["bridge.login_shared_secret"]:
             base["bridge.login_shared_secret_map"] = {
                 base["homeserver.domain"]: self["bridge.login_shared_secret"]

--- a/mautrix_signal/example-config.yaml
+++ b/mautrix_signal/example-config.yaml
@@ -238,6 +238,8 @@ bridge:
     # Requires the user to have sufficient power level and double puppeting enabled.
     create_group_on_invite: true
     hacky_contact_name_mixup_detection: false
+    # Preliminary support for MSC2530. This only works for media messages and will not work by default on most clients
+    caption_in_message: false
 
     # Provisioning API part of the web server for automated portal creation and fetching information.
     # Used by things like mautrix-manager (https://github.com/tulir/mautrix-manager).

--- a/mautrix_signal/portal.py
+++ b/mautrix_signal/portal.py
@@ -446,6 +446,8 @@ class Portal(DBPortal, BasePortal):
             attachment = await self._make_attachment(message, attachment_path)
             attachments = [attachment]
             text = message.body if is_relay else None
+            if self.config["bridge.caption_in_message"]:
+                text = message.body if message.get("filename") is not None else None
             self.log.trace("Formed outgoing attachment %s", attachment)
         elif message.msgtype == MessageType.LOCATION:
             try:


### PR DESCRIPTION
Added basic support for [MSC2530](https://github.com/tulir/matrix-spec-proposals/blob/body-as-caption/proposals/2530-body-as-caption.md). 

I have currently only implemented the filename field in the media message, and created a configuration variable like in [mautrix-instagram](https://github.com/mautrix/instagram/pull/58).