### PR TITLE
Refactor database tables and query wrappers

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -57,6 +57,7 @@ func (br *SignalBridge) RegisterCommands() {
 		cmdUnsetRelay,
 		cmdDeletePortal,
 		cmdDeleteAllPortals,
+		cmdCleanupLostPortals,
 	)
 }
 
@@ -473,4 +474,40 @@ func fnDeleteAllPortals(ce *WrappedCommandEvent) {
 		}
 		ce.Reply("Finished background cleanup of deleted portal rooms.")
 	}()
+}
+
+var cmdCleanupLostPortals = &commands.FullHandler{
+	Func: wrapCommand(fnCleanupLostPortals),
+	Name: "cleanup-lost-portals",
+	Help: commands.HelpMeta{
+		Section:     HelpSectionPortalManagement,
+		Description: "Clean up portals that were discarded due to the receiver not being logged into the bridge",
+	},
+	RequiresAdmin: true,
+}
+
+func fnCleanupLostPortals(ce *WrappedCommandEvent) {
+	portals, err := ce.Bridge.DB.LostPortal.GetAll(context.TODO())
+	if err != nil {
+		ce.Reply("Failed to get portals: %v", err)
+		return
+	} else if len(portals) == 0 {
+		ce.Reply("No lost portals found")
+		return
+	}
+
+	ce.Reply("Found %d lost portals, deleting...", len(portals))
+	for _, portal := range portals {
+		dmUUID, err := uuid.Parse(portal.ChatID)
+		intent := ce.Bot
+		if err == nil {
+			intent = ce.Bridge.GetPuppetBySignalID(dmUUID).DefaultIntent()
+		}
+		ce.Bridge.CleanupRoom(ce.ZLog, intent, portal.MXID, false)
+		err = portal.Delete(context.TODO())
+		if err != nil {
+			ce.ZLog.Err(err).Msg("Failed to delete lost portal from database after cleanup")
+		}
+	}
+	ce.Reply("Finished cleaning up portals")
 }

--- a/database/database.go
+++ b/database/database.go
@@ -1,5 +1,5 @@
 // mautrix-signal - A Matrix-signal puppeting bridge.
-// Copyright (C) 2023 Scott Weber
+// Copyright (C) 2023 Scott Weber, Tulir Asokan
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by
@@ -21,8 +21,8 @@ import (
 
 	_ "github.com/lib/pq"
 	_ "github.com/mattn/go-sqlite3"
+
 	"go.mau.fi/util/dbutil"
-	"maunium.net/go/maulogger/v2"
 
 	"go.mau.fi/mautrix-signal/database/upgrades"
 )
@@ -38,39 +38,15 @@ type Database struct {
 	DisappearingMessage *DisappearingMessageQuery
 }
 
-func New(baseDB *dbutil.Database, log maulogger.Logger) *Database {
-	db := &Database{Database: baseDB}
+func New(db *dbutil.Database) *Database {
 	db.UpgradeTable = upgrades.Table
-	db.User = &UserQuery{
-		db:  db,
-		log: log.Sub("User"),
+	return &Database{
+		Database:            db,
+		User:                &UserQuery{dbutil.MakeQueryHelper(db, newUser)},
+		Portal:              &PortalQuery{dbutil.MakeQueryHelper(db, newPortal)},
+		Puppet:              &PuppetQuery{dbutil.MakeQueryHelper(db, newPuppet)},
+		Message:             &MessageQuery{dbutil.MakeQueryHelper(db, newMessage)},
+		Reaction:            &ReactionQuery{dbutil.MakeQueryHelper(db, newReaction)},
+		DisappearingMessage: &DisappearingMessageQuery{dbutil.MakeQueryHelper(db, newDisappearingMessage)},
 	}
-	db.Portal = &PortalQuery{
-		db:  db,
-		log: log.Sub("Portal"),
-	}
-	db.Puppet = &PuppetQuery{
-		db:  db,
-		log: log.Sub("Puppet"),
-	}
-	db.Message = &MessageQuery{
-		db:  db,
-		log: log.Sub("Message"),
-	}
-	db.Reaction = &ReactionQuery{
-		db:  db,
-		log: log.Sub("Reaction"),
-	}
-	db.DisappearingMessage = &DisappearingMessageQuery{
-		db:  db,
-		log: log.Sub("DisappearingMessage"),
-	}
-	return db
-}
-
-func strPtr(val string) *string {
-	if val == "" {
-		return nil
-	}
-	return &val
 }

--- a/database/database.go
+++ b/database/database.go
@@ -21,7 +21,6 @@ import (
 
 	_ "github.com/lib/pq"
 	_ "github.com/mattn/go-sqlite3"
-
 	"go.mau.fi/util/dbutil"
 
 	"go.mau.fi/mautrix-signal/database/upgrades"

--- a/database/database.go
+++ b/database/database.go
@@ -32,6 +32,7 @@ type Database struct {
 
 	User                *UserQuery
 	Portal              *PortalQuery
+	LostPortal          *LostPortalQuery
 	Puppet              *PuppetQuery
 	Message             *MessageQuery
 	Reaction            *ReactionQuery
@@ -44,6 +45,7 @@ func New(db *dbutil.Database) *Database {
 		Database:            db,
 		User:                &UserQuery{dbutil.MakeQueryHelper(db, newUser)},
 		Portal:              &PortalQuery{dbutil.MakeQueryHelper(db, newPortal)},
+		LostPortal:          &LostPortalQuery{dbutil.MakeQueryHelper(db, newLostPortal)},
 		Puppet:              &PuppetQuery{dbutil.MakeQueryHelper(db, newPuppet)},
 		Message:             &MessageQuery{dbutil.MakeQueryHelper(db, newMessage)},
 		Reaction:            &ReactionQuery{dbutil.MakeQueryHelper(db, newReaction)},

--- a/database/disappearingmessage.go
+++ b/database/disappearingmessage.go
@@ -1,5 +1,5 @@
 // mautrix-signal - A Matrix-signal puppeting bridge.
-// Copyright (C) 2023 Scott Weber
+// Copyright (C) 2023 Scott Weber, Tulir Asokan
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by
@@ -17,136 +17,110 @@
 package database
 
 import (
+	"context"
 	"database/sql"
-	"errors"
 	"time"
 
 	"go.mau.fi/util/dbutil"
-	log "maunium.net/go/maulogger/v2"
 
 	"maunium.net/go/mautrix/id"
 )
 
+const (
+	getUnscheduledDisappearingMessagesForRoomQuery = `
+		SELECT room_id, mxid, expiration_seconds, expiration_ts
+		FROM disappearing_message WHERE expiration_ts IS NULL AND room_id = $1
+	`
+	getExpiredDisappearingMessagesQuery = `
+		SELECT room_id, mxid, expiration_seconds, expiration_ts
+		FROM disappearing_message WHERE expiration_ts IS NOT NULL AND expiration_ts <= $1
+	`
+	getNextDisappearingMessageQuery = `
+		SELECT room_id, mxid, expiration_seconds, expiration_ts
+		FROM disappearing_message WHERE expiration_ts IS NOT NULL ORDER BY expiration_ts ASC LIMIT 1
+	`
+	insertDisappearingMessageQuery = `
+		INSERT INTO disappearing_message (room_id, mxid, expiration_seconds, expiration_ts) VALUES ($1, $2, $3, $4)
+	`
+	updateDisappearingMessageQuery = `
+		UPDATE disappearing_message SET expiration_ts=$2 WHERE mxid=$1
+	`
+	deleteDisappearingMessageQuery = `
+		DELETE FROM disappearing_message WHERE mxid=$1
+	`
+)
+
 type DisappearingMessageQuery struct {
-	db  *Database
-	log log.Logger
-}
-
-func (dmq *DisappearingMessageQuery) New() *DisappearingMessage {
-	return &DisappearingMessage{
-		db:  dmq.db,
-		log: dmq.log,
-	}
-}
-
-func (dmq *DisappearingMessageQuery) NewWithValues(roomID id.RoomID, eventID id.EventID, expireInSeconds int64, expireAt time.Time) *DisappearingMessage {
-	dm := &DisappearingMessage{
-		db:              dmq.db,
-		log:             dmq.log,
-		RoomID:          roomID,
-		EventID:         eventID,
-		ExpireInSeconds: expireInSeconds,
-		ExpireAt:        expireAt,
-	}
-	return dm
-}
-
-func (dmq *DisappearingMessageQuery) GetUnscheduledForRoom(roomID id.RoomID) (messages []*DisappearingMessage) {
-	const getUnscheduledQuery = `
-		SELECT room_id, mxid, expiration_seconds, expiration_ts FROM disappearing_message WHERE expiration_ts IS NULL AND room_id = $1
-	`
-	rows, err := dmq.db.Query(getUnscheduledQuery, roomID)
-	if err != nil || rows == nil {
-		dmq.log.Warnln("Failed to get unscheduled disappearing messages:", err)
-		return nil
-	}
-	for rows.Next() {
-		messages = append(messages, dmq.New().Scan(rows))
-	}
-	return
-}
-
-func (dmq *DisappearingMessageQuery) GetExpiredMessages() (messages []*DisappearingMessage) {
-	const getExpiredQuery = `
-		SELECT room_id, mxid, expiration_seconds, expiration_ts FROM disappearing_message WHERE expiration_ts IS NOT NULL AND expiration_ts <= $1
-	`
-	const wiggleRoom = 1
-	rows, err := dmq.db.Query(getExpiredQuery, time.Now().Unix()+wiggleRoom)
-	if err != nil || rows == nil {
-		dmq.log.Warnln("Failed to get expired disappearing messages:", err)
-		return nil
-	}
-	for rows.Next() {
-		messages = append(messages, dmq.New().Scan(rows))
-	}
-	return
-}
-
-func (dmq *DisappearingMessageQuery) GetNextScheduledMessage() (message *DisappearingMessage) {
-	const getNextScheduledQuery = `
-		SELECT room_id, mxid, expiration_seconds, expiration_ts FROM disappearing_message WHERE expiration_ts IS NOT NULL ORDER BY expiration_ts ASC LIMIT 1
-	`
-	row := dmq.db.QueryRow(getNextScheduledQuery)
-	if row == nil {
-		return nil
-	}
-	return dmq.New().Scan(row)
+	*dbutil.QueryHelper[*DisappearingMessage]
 }
 
 type DisappearingMessage struct {
-	db  *Database
-	log log.Logger
+	qh *dbutil.QueryHelper[*DisappearingMessage]
 
-	RoomID          id.RoomID
-	EventID         id.EventID
-	ExpireInSeconds int64
-	ExpireAt        time.Time
+	RoomID   id.RoomID
+	EventID  id.EventID
+	ExpireIn time.Duration
+	ExpireAt time.Time
 }
 
-func (msg *DisappearingMessage) Scan(row dbutil.Scannable) *DisappearingMessage {
+func newDisappearingMessage(qh *dbutil.QueryHelper[*DisappearingMessage]) *DisappearingMessage {
+	return &DisappearingMessage{qh: qh}
+}
+
+func (dmq *DisappearingMessageQuery) NewWithValues(roomID id.RoomID, eventID id.EventID, expireIn time.Duration, expireAt time.Time) *DisappearingMessage {
+	return &DisappearingMessage{
+		qh:       dmq.QueryHelper,
+		RoomID:   roomID,
+		EventID:  eventID,
+		ExpireIn: expireIn,
+		ExpireAt: expireAt,
+	}
+}
+
+func (dmq *DisappearingMessageQuery) GetUnscheduledForRoom(ctx context.Context, roomID id.RoomID) ([]*DisappearingMessage, error) {
+	return dmq.QueryMany(ctx, getUnscheduledDisappearingMessagesForRoomQuery, roomID)
+}
+
+func (dmq *DisappearingMessageQuery) GetExpiredMessages(ctx context.Context) ([]*DisappearingMessage, error) {
+	return dmq.QueryMany(ctx, getExpiredDisappearingMessagesQuery, time.Now().Unix()+1)
+}
+
+func (dmq *DisappearingMessageQuery) GetNextScheduledMessage(ctx context.Context) (*DisappearingMessage, error) {
+	return dmq.QueryOne(ctx, getNextDisappearingMessageQuery)
+}
+
+func (msg *DisappearingMessage) Scan(row dbutil.Scannable) (*DisappearingMessage, error) {
 	var expireIn int64
 	var expireAt sql.NullInt64
 	err := row.Scan(&msg.RoomID, &msg.EventID, &expireIn, &expireAt)
 	if err != nil {
-		if !errors.Is(err, sql.ErrNoRows) {
-			msg.log.Errorln("Database scan failed:", err)
-		}
-		return nil
+		return nil, err
 	}
-	msg.ExpireInSeconds = expireIn
+	msg.ExpireIn = time.Duration(expireIn) * time.Second
 	if expireAt.Valid {
 		msg.ExpireAt = time.Unix(expireAt.Int64, 0)
 	}
-	return msg
+	return msg, nil
 }
 
-func (msg *DisappearingMessage) Insert(txn dbutil.Execable) {
-	if txn == nil {
-		txn = msg.db
-	}
+func (msg *DisappearingMessage) sqlVariables() []any {
 	var expireAt sql.NullInt64
 	if !msg.ExpireAt.IsZero() {
 		expireAt.Valid = true
 		expireAt.Int64 = msg.ExpireAt.Unix()
 	}
-	_, err := txn.Exec(`INSERT INTO disappearing_message (room_id, mxid, expiration_seconds, expiration_ts) VALUES ($1, $2, $3, $4)`,
-		msg.RoomID, msg.EventID, msg.ExpireInSeconds, expireAt)
-	if err != nil {
-		msg.log.Warnfln("Failed to insert %s/%s: %v", msg.RoomID, msg.EventID, err)
-	}
+	return []any{msg.RoomID, msg.EventID, int64(msg.ExpireIn.Seconds()), expireAt}
 }
 
-func (msg *DisappearingMessage) StartExpirationTimer() {
-	msg.ExpireAt = time.Now().Add(time.Duration(msg.ExpireInSeconds) * time.Second)
-	_, err := msg.db.Exec("UPDATE disappearing_message SET expiration_ts=$1 WHERE room_id=$2 AND mxid=$3", msg.ExpireAt.Unix(), msg.RoomID, msg.EventID)
-	if err != nil {
-		msg.log.Warnfln("Failed to update %s/%s: %v", msg.RoomID, msg.EventID, err)
-	}
+func (msg *DisappearingMessage) Insert(ctx context.Context) error {
+	return msg.qh.Exec(ctx, insertDisappearingMessageQuery, msg.sqlVariables()...)
 }
 
-func (msg *DisappearingMessage) Delete() {
-	_, err := msg.db.Exec("DELETE FROM disappearing_message WHERE room_id=$1 AND mxid=$2", msg.RoomID, msg.EventID)
-	if err != nil {
-		msg.log.Warnfln("Failed to delete %s/%s: %v", msg.RoomID, msg.EventID, err)
-	}
+func (msg *DisappearingMessage) StartExpirationTimer(ctx context.Context) error {
+	msg.ExpireAt = time.Now().Add(msg.ExpireIn)
+	return msg.qh.Exec(ctx, updateDisappearingMessageQuery, msg.EventID, msg.ExpireAt.Unix())
+}
+
+func (msg *DisappearingMessage) Delete(ctx context.Context) error {
+	return msg.qh.Exec(ctx, deleteDisappearingMessageQuery, msg.EventID)
 }

--- a/database/disappearingmessage.go
+++ b/database/disappearingmessage.go
@@ -22,7 +22,6 @@ import (
 	"time"
 
 	"go.mau.fi/util/dbutil"
-
 	"maunium.net/go/mautrix/id"
 )
 

--- a/database/lostportal.go
+++ b/database/lostportal.go
@@ -1,0 +1,58 @@
+// mautrix-signal - A Matrix-signal puppeting bridge.
+// Copyright (C) 2023 Tulir Asokan
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package database
+
+import (
+	"context"
+
+	"go.mau.fi/util/dbutil"
+	"maunium.net/go/mautrix/id"
+)
+
+const (
+	getLostPortalsQuery   = `SELECT chat_id, receiver, mxid FROM lost_portals`
+	deleteLostPortalQuery = `DELETE FROM lost_portals WHERE mxid=$1`
+)
+
+type LostPortalQuery struct {
+	*dbutil.QueryHelper[*LostPortal]
+}
+
+func (lpq *LostPortalQuery) GetAll(ctx context.Context) ([]*LostPortal, error) {
+	return lpq.QueryMany(ctx, getLostPortalsQuery)
+}
+
+type LostPortal struct {
+	qh *dbutil.QueryHelper[*LostPortal]
+
+	ChatID   string
+	Receiver string
+	MXID     id.RoomID
+}
+
+func newLostPortal(qh *dbutil.QueryHelper[*LostPortal]) *LostPortal {
+	return &LostPortal{qh: qh}
+}
+
+func (l *LostPortal) Scan(row dbutil.Scannable) (*LostPortal, error) {
+	err := row.Scan(&l.ChatID, &l.Receiver, &l.MXID)
+	return l, err
+}
+
+func (l *LostPortal) Delete(ctx context.Context) error {
+	return l.qh.Exec(ctx, deleteLostPortalQuery, l.MXID)
+}

--- a/database/message.go
+++ b/database/message.go
@@ -22,9 +22,8 @@ import (
 	"strings"
 
 	"github.com/google/uuid"
-	"maunium.net/go/mautrix/id"
-
 	"go.mau.fi/util/dbutil"
+	"maunium.net/go/mautrix/id"
 )
 
 const (

--- a/database/portal.go
+++ b/database/portal.go
@@ -1,5 +1,5 @@
 // mautrix-signal - A Matrix-signal puppeting bridge.
-// Copyright (C) 2023 Scott Weber
+// Copyright (C) 2023 Scott Weber, Tulir Asokan
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by
@@ -17,49 +17,75 @@
 package database
 
 import (
+	"context"
 	"database/sql"
-	"errors"
-	"fmt"
+
+	"github.com/google/uuid"
+	"maunium.net/go/mautrix/id"
 
 	"go.mau.fi/util/dbutil"
-	log "maunium.net/go/maulogger/v2"
-	"maunium.net/go/mautrix/id"
+
+	"go.mau.fi/mautrix-signal/pkg/signalmeow"
+)
+
+const (
+	portalBaseSelect = `
+		SELECT chat_id, receiver, mxid, name, topic, avatar_hash, avatar_url, name_set, avatar_set,
+		       revision, encrypted, relay_user_id, expiration_time
+		FROM portal
+	`
+	getPortalByMXIDQuery       = portalBaseSelect + `WHERE mxid=$1`
+	getPortalByChatIDQuery     = portalBaseSelect + `WHERE chat_id=$1 AND receiver=$2`
+	getPortalsByReceiver       = portalBaseSelect + `WHERE receiver=$1`
+	getAllPortalsWithMXIDQuery = portalBaseSelect + `WHERE mxid IS NOT NULL`
+	insertPortalQuery          = `
+		INSERT INTO portal (
+			chat_id, receiver, mxid, name, topic, avatar_hash, avatar_url, name_set, avatar_set,
+			revision, encrypted, relay_user_id, expiration_time
+		) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)
+	`
+	updatePortalQuery = `
+		UPDATE portal SET
+			mxid=$3, name=$4, topic=$5, avatar_hash=$6, avatar_url=$7, name_set=$8,
+			avatar_set=$9, revision=$10, encrypted=$11, relay_user_id=$12,
+			expiration_time=$13
+		WHERE chat_id=$1 AND receiver=$2
+	`
+	deletePortalQuery = `DELETE FROM portal WHERE chat_id=$1 AND receiver=$2`
 )
 
 type PortalQuery struct {
-	db  *Database
-	log log.Logger
-}
-
-func (pq *PortalQuery) New() *Portal {
-	return &Portal{
-		db:  pq.db,
-		log: pq.log,
-	}
+	*dbutil.QueryHelper[*Portal]
 }
 
 type PortalKey struct {
 	ChatID   string
-	Receiver string
+	Receiver uuid.UUID
 }
 
-func NewPortalKey(chatID, receiver string) PortalKey {
+func (pk *PortalKey) UserID() uuid.UUID {
+	parsed, _ := uuid.Parse(pk.ChatID)
+	return parsed
+}
+
+func (pk *PortalKey) GroupID() signalmeow.GroupIdentifier {
+	if len(pk.ChatID) == 44 {
+		return signalmeow.GroupIdentifier(pk.ChatID)
+	}
+	return ""
+}
+
+func NewPortalKey(chatID string, receiver uuid.UUID) PortalKey {
 	return PortalKey{
 		ChatID:   chatID,
 		Receiver: receiver,
 	}
 }
 
-func (key PortalKey) String() string {
-	return fmt.Sprintf("%s:%s", key.ChatID, key.Receiver)
-}
-
 type Portal struct {
-	db  *Database
-	log log.Logger
+	qh *dbutil.QueryHelper[*Portal]
 
-	ChatID         string
-	Receiver       string
+	PortalKey
 	MXID           id.RoomID
 	Name           string
 	Topic          string
@@ -73,15 +99,59 @@ type Portal struct {
 	ExpirationTime int
 }
 
-func (p *Portal) values() []interface{} {
-	return []interface{}{
+func newPortal(qh *dbutil.QueryHelper[*Portal]) *Portal {
+	return &Portal{qh: qh}
+}
+
+func (pq *PortalQuery) GetByMXID(ctx context.Context, mxid id.RoomID) (*Portal, error) {
+	return pq.QueryOne(ctx, getPortalByMXIDQuery, mxid)
+}
+
+func (pq *PortalQuery) GetByChatID(ctx context.Context, pk PortalKey) (*Portal, error) {
+	return pq.QueryOne(ctx, getPortalByChatIDQuery, pk.ChatID, pk.Receiver)
+}
+
+func (pq *PortalQuery) FindPrivateChatsOf(ctx context.Context, receiver uuid.UUID) ([]*Portal, error) {
+	return pq.QueryMany(ctx, getPortalsByReceiver, receiver)
+}
+
+func (pq *PortalQuery) GetAllWithMXID(ctx context.Context) ([]*Portal, error) {
+	return pq.QueryMany(ctx, getAllPortalsWithMXIDQuery)
+}
+
+func (p *Portal) Scan(row dbutil.Scannable) (*Portal, error) {
+	var mxid sql.NullString
+	err := row.Scan(
+		&p.ChatID,
+		&p.Receiver,
+		&mxid,
+		&p.Name,
+		&p.Topic,
+		&p.AvatarHash,
+		&p.AvatarURL,
+		&p.NameSet,
+		&p.AvatarSet,
+		&p.Revision,
+		&p.Encrypted,
+		&p.RelayUserID,
+		&p.ExpirationTime,
+	)
+	if err != nil {
+		return nil, err
+	}
+	p.MXID = id.RoomID(mxid.String)
+	return p, nil
+}
+
+func (p *Portal) sqlVariables() []any {
+	return []any{
 		p.ChatID,
 		p.Receiver,
-		p.MXID,
+		dbutil.StrPtr(p.MXID),
 		p.Name,
 		p.Topic,
 		p.AvatarHash,
-		p.AvatarURL.String(),
+		p.AvatarURL,
 		p.NameSet,
 		p.AvatarSet,
 		p.Revision,
@@ -91,194 +161,14 @@ func (p *Portal) values() []interface{} {
 	}
 }
 
-func (p *Portal) Scan(row dbutil.Scannable) *Portal {
-	if row == nil {
-		p.log.Debugln("nil row passed to Portal.Scan")
-		return nil
-	}
-	var chatID, receiver, mxid, name, topic, avatarHash, avatarURL, relayUserID sql.NullString
-	var expirationTime sql.NullInt64
-	err := row.Scan(
-		&chatID,
-		&receiver,
-		&mxid,
-		&name,
-		&topic,
-		&avatarHash,
-		&avatarURL,
-		&p.NameSet,
-		&p.AvatarSet,
-		&p.Revision,
-		&p.Encrypted,
-		&relayUserID,
-		&expirationTime,
-	)
-	if err != nil {
-		if !errors.Is(err, sql.ErrNoRows) {
-			p.log.Warnfln("Error scanning portal row: %w", err)
-		} else {
-			p.log.Debugln("No portal row found")
-		}
-		return nil
-	}
-	p.ChatID = chatID.String
-	p.Receiver = receiver.String
-	p.MXID = id.RoomID(mxid.String)
-	p.Name = name.String
-	p.Topic = topic.String
-	p.AvatarHash = avatarHash.String
-	p.RelayUserID = id.UserID(relayUserID.String)
-	p.ExpirationTime = int(expirationTime.Int64)
-	parsedAvatarURL, err := id.ParseContentURI(avatarURL.String)
-	if err != nil {
-		p.log.Warnfln("Error parsing avatar URL: %w", err)
-		p.AvatarURL = id.ContentURI{}
-	} else {
-		p.AvatarURL = parsedAvatarURL
-	}
-	return p
+func (p *Portal) Insert(ctx context.Context) error {
+	return p.qh.Exec(ctx, insertPortalQuery, p.sqlVariables()...)
 }
 
-func (p *Portal) SetPortalKey(pk PortalKey) {
-	p.ChatID = pk.ChatID
-	p.Receiver = pk.Receiver
+func (p *Portal) Update(ctx context.Context) error {
+	return p.qh.Exec(ctx, updatePortalQuery, p.sqlVariables()...)
 }
 
-func (p *Portal) Key() PortalKey {
-	return PortalKey{
-		ChatID:   p.ChatID,
-		Receiver: p.Receiver,
-	}
-}
-
-func (p *Portal) Insert() error {
-	q := `
-	INSERT INTO portal (
-		chat_id, receiver, mxid, name, topic, avatar_hash, avatar_url, name_set, avatar_set,
-		revision, encrypted, relay_user_id, expiration_time
-	) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)
-	`
-	_, err := p.db.Exec(q, p.values()...)
-	return err
-}
-
-func (p *Portal) Update() error {
-	q := `
-	UPDATE portal SET mxid=$3, name=$4, topic=$5, avatar_hash=$6, avatar_url=$7, name_set=$8,
-	                  avatar_set=$9, revision=$10, encrypted=$11, relay_user_id=$12,
-	                  expiration_time=$13
-	WHERE chat_id=$1 AND receiver=$2
-	`
-	_, err := p.db.Exec(q, p.values()...)
-	return err
-}
-
-func (p *Portal) Delete() error {
-	q := "DELETE FROM portal WHERE chat_id=$1 AND receiver=$2"
-	_, err := p.db.Exec(q, p.ChatID, p.Receiver)
-	return err
-}
-
-const (
-	portalColumns = `
-        chat_id, receiver, mxid, name, topic, avatar_hash, avatar_url, name_set, avatar_set,
-        revision, encrypted, relay_user_id, expiration_time
-	`
-)
-
-func (pq *PortalQuery) GetByMXID(mxid id.RoomID) *Portal {
-	q := fmt.Sprintf("SELECT %s FROM portal WHERE mxid=$1", portalColumns)
-	log.Debugfln("mxid: %s", mxid.String())
-	log.Debugfln("QUERY: %s", q)
-	row := pq.db.QueryRow(q, mxid.String())
-	log.Debugfln("ROW: %s", row)
-	p := pq.New()
-	return p.Scan(row)
-}
-
-func (pq *PortalQuery) GetByChatID(pk PortalKey) *Portal {
-	q := fmt.Sprintf("SELECT %s FROM portal WHERE chat_id=$1 AND receiver=$2", portalColumns)
-	log.Debugfln("QUERY: %s", q)
-	row := pq.db.QueryRow(q, pk.ChatID, pk.Receiver)
-	log.Debugfln("ROW: %s", row)
-	p := pq.New()
-	return p.Scan(row)
-}
-
-func (pq *PortalQuery) FindPrivateChatsOf(receiver string) []*Portal {
-	q := fmt.Sprintf("SELECT %s FROM portal WHERE receiver=$1", portalColumns)
-	rows, err := pq.db.Query(q, receiver)
-	log.Debugfln("receiver: %s", receiver)
-	log.Debugfln("QUERY: %s", q)
-	if err != nil {
-		pq.log.Warnfln("Error querying private chats of %s: %w", receiver, err)
-		return nil
-	}
-	defer rows.Close()
-	var portals []*Portal
-	for rows.Next() {
-		p := pq.New()
-		if p.Scan(rows) != nil {
-			portals = append(portals, p)
-		}
-	}
-	return portals
-}
-
-func (pq *PortalQuery) FindPrivateChatsWith(otherUser string) []*Portal {
-	q := fmt.Sprintf("SELECT %s FROM portal WHERE chat_id=$1 AND receiver<>''", portalColumns)
-	rows, err := pq.db.Query(q, otherUser)
-	log.Debugfln("otherUser: %s", otherUser)
-	log.Debugfln("QUERY: %s", q)
-	if err != nil {
-		pq.log.Warnfln("Error querying private chats with %s: %w", otherUser, err)
-		return nil
-	}
-	defer rows.Close()
-	var portals []*Portal
-	for rows.Next() {
-		p := pq.New()
-		if p.Scan(rows) != nil {
-			portals = append(portals, p)
-		}
-	}
-	return portals
-}
-
-func (pq *PortalQuery) AllWithRoom() []*Portal {
-	q := fmt.Sprintf("SELECT %s FROM portal WHERE mxid IS NOT NULL", portalColumns)
-	rows, err := pq.db.Query(q)
-	log.Debugfln("BY ISTESF QUERY: %s", q)
-	if err != nil {
-		pq.log.Warnfln("Error querying all portals with room: %w", err)
-		return nil
-	}
-	defer rows.Close()
-	var portals []*Portal
-	for rows.Next() {
-		p := pq.New()
-		if p.Scan(rows) != nil {
-			portals = append(portals, p)
-		}
-	}
-	return portals
-}
-
-func (pq *PortalQuery) GetAll() []*Portal {
-	q := fmt.Sprintf("SELECT %s FROM portal", portalColumns)
-	rows, err := pq.db.Query(q)
-	log.Debugfln("ALLQUERY: %s", q)
-	if err != nil {
-		pq.log.Warnfln("Error querying all portals: %w", err)
-		return nil
-	}
-	defer rows.Close()
-	var portals []*Portal
-	for rows.Next() {
-		p := pq.New()
-		if p.Scan(rows) != nil {
-			portals = append(portals, p)
-		}
-	}
-	return portals
+func (p *Portal) Delete(ctx context.Context) error {
+	return p.qh.Exec(ctx, deletePortalQuery, p.ChatID, p.Receiver)
 }

--- a/database/portal.go
+++ b/database/portal.go
@@ -21,9 +21,8 @@ import (
 	"database/sql"
 
 	"github.com/google/uuid"
-	"maunium.net/go/mautrix/id"
-
 	"go.mau.fi/util/dbutil"
+	"maunium.net/go/mautrix/id"
 
 	"go.mau.fi/mautrix-signal/pkg/signalmeow"
 )

--- a/database/puppet.go
+++ b/database/puppet.go
@@ -21,9 +21,8 @@ import (
 	"database/sql"
 
 	"github.com/google/uuid"
-	"maunium.net/go/mautrix/id"
-
 	"go.mau.fi/util/dbutil"
+	"maunium.net/go/mautrix/id"
 )
 
 const (

--- a/database/reaction.go
+++ b/database/reaction.go
@@ -20,9 +20,8 @@ import (
 	"context"
 
 	"github.com/google/uuid"
-	"maunium.net/go/mautrix/id"
-
 	"go.mau.fi/util/dbutil"
+	"maunium.net/go/mautrix/id"
 )
 
 const (

--- a/database/upgrades/00-latest.sql
+++ b/database/upgrades/00-latest.sql
@@ -1,87 +1,97 @@
--- v0 -> v15: Latest revision
+-- v0 -> v17: Latest revision
 
 CREATE TABLE portal (
-    chat_id     TEXT,
-    receiver    TEXT,
+    chat_id     TEXT    NOT NULL,
+    receiver    uuid    NOT NULL,
     mxid        TEXT,
-    name        TEXT,
-    topic       TEXT,
+    name        TEXT    NOT NULL,
+    topic       TEXT    NOT NULL,
     encrypted   BOOLEAN NOT NULL DEFAULT false,
-    avatar_hash TEXT,
-    avatar_url  TEXT,
+    avatar_hash TEXT    NOT NULL,
+    avatar_url  TEXT    NOT NULL,
     name_set    BOOLEAN NOT NULL DEFAULT false,
     avatar_set  BOOLEAN NOT NULL DEFAULT false,
     revision    INTEGER NOT NULL DEFAULT 0,
-    expiration_time BIGINT,
-    relay_user_id   TEXT,
 
-    PRIMARY KEY (chat_id, receiver)
+    expiration_time BIGINT NOT NULL,
+    relay_user_id   TEXT   NOT NULL,
+
+    PRIMARY KEY (chat_id, receiver),
+    CONSTRAINT portal_mxid_unique UNIQUE(mxid)
 );
 
 CREATE TABLE puppet (
-    uuid         UUID PRIMARY KEY,
-    number       TEXT UNIQUE,
-    name         TEXT,
-    name_quality INTEGER NOT NULL DEFAULT 0,
-    avatar_hash  TEXT,
-    avatar_url   TEXT,
+    uuid         uuid    PRIMARY KEY,
+    number       TEXT    UNIQUE,
+    name         TEXT    NOT NULL,
+    name_quality INTEGER NOT NULL,
+    avatar_hash  TEXT    NOT NULL,
+    avatar_url   TEXT    NOT NULL,
     name_set     BOOLEAN NOT NULL DEFAULT false,
     avatar_set   BOOLEAN NOT NULL DEFAULT false,
 
-    is_registered BOOLEAN NOT NULL DEFAULT false,
+    is_registered    BOOLEAN NOT NULL DEFAULT false,
+    contact_info_set BOOLEAN NOT NULL DEFAULT false,
 
     custom_mxid  TEXT,
-    access_token TEXT,
-    contact_info_set BOOLEAN NOT NULL DEFAULT false
+    access_token TEXT NOT NULL,
+
+    CONSTRAINT puppet_custom_mxid_unique UNIQUE(custom_mxid)
 );
 
 CREATE TABLE "user" (
-    mxid            TEXT PRIMARY KEY,
-    username        TEXT,
-    uuid            UUID,
-    management_room TEXT
+    mxid  TEXT PRIMARY KEY,
+    uuid  uuid,
+    phone TEXT,
+
+    management_room TEXT,
+
+    CONSTRAINT user_uuid_unique UNIQUE(uuid)
 );
 
 CREATE TABLE message (
+    sender     uuid    NOT NULL,
+    timestamp  BIGINT  NOT NULL,
+    part_index INTEGER NOT NULL,
+
+    signal_chat_id  TEXT NOT NULL,
+    signal_receiver uuid NOT NULL,
+
     mxid    TEXT NOT NULL,
     mx_room TEXT NOT NULL,
-    sender          UUID,
-    timestamp       BIGINT,
-    signal_chat_id  TEXT,
-    signal_receiver TEXT,
 
-    PRIMARY KEY (sender, timestamp, signal_chat_id, signal_receiver),
-    FOREIGN KEY (signal_chat_id, signal_receiver) REFERENCES portal(chat_id, receiver) ON DELETE CASCADE,
+    PRIMARY KEY (sender, timestamp, part_index, signal_receiver),
+    CONSTRAINT message_portal_fkey FOREIGN KEY (signal_chat_id, signal_receiver)
+        REFERENCES portal(chat_id, receiver) ON DELETE CASCADE ON UPDATE CASCADE,
     FOREIGN KEY (sender) REFERENCES puppet(uuid) ON DELETE CASCADE,
-    UNIQUE (mxid, mx_room)
+    CONSTRAINT message_mxid_unique UNIQUE (mxid)
 );
 
 CREATE TABLE reaction (
-    mxid            TEXT   NOT NULL,
-    mx_room         TEXT   NOT NULL,
+    msg_author    uuid    NOT NULL,
+    msg_timestamp BIGINT  NOT NULL,
+    -- part_index is not used in reactions, but is required for the foreign key.
+    _part_index   INTEGER NOT NULL DEFAULT 0,
 
-    signal_chat_id  TEXT   NOT NULL,
-    signal_receiver TEXT   NOT NULL,
+    author uuid NOT NULL,
+    emoji  TEXT NOT NULL,
 
-    author          UUID   NOT NULL,
-    msg_author      UUID   NOT NULL,
-    msg_timestamp   BIGINT NOT NULL,
-    emoji           TEXT   NOT NULL,
+    signal_chat_id  TEXT NOT NULL,
+    signal_receiver uuid NOT NULL,
 
-    PRIMARY KEY (signal_chat_id, signal_receiver, msg_author, msg_timestamp, author),
-    CONSTRAINT reaction_message_fkey
-    FOREIGN KEY (msg_author, msg_timestamp, signal_chat_id, signal_receiver)
-    REFERENCES message(sender, timestamp, signal_chat_id, signal_receiver)
-    ON DELETE CASCADE,
+    mxid    TEXT NOT NULL,
+    mx_room TEXT NOT NULL,
+
+    PRIMARY KEY (msg_author, msg_timestamp, author, signal_receiver),
+    CONSTRAINT reaction_message_fkey FOREIGN KEY (msg_author, msg_timestamp, _part_index, signal_receiver)
+        REFERENCES message (sender, timestamp, part_index, signal_receiver) ON DELETE CASCADE ON UPDATE CASCADE,
     FOREIGN KEY (author) REFERENCES puppet(uuid) ON DELETE CASCADE,
-    UNIQUE (mxid, mx_room)
+    CONSTRAINT reaction_mxid_unique UNIQUE (mxid)
 );
 
 CREATE TABLE disappearing_message (
-    room_id             TEXT,
-    mxid                TEXT,
-    expiration_seconds  BIGINT,
-    expiration_ts       BIGINT,
-
-    PRIMARY KEY (room_id, mxid)
+    mxid                TEXT   NOT NULL PRIMARY KEY,
+    room_id             TEXT   NOT NULL,
+    expiration_seconds  BIGINT NOT NULL,
+    expiration_ts       BIGINT
 );

--- a/database/upgrades/16-refactor-postgres.sql
+++ b/database/upgrades/16-refactor-postgres.sql
@@ -1,0 +1,104 @@
+-- v16: Refactor types (Postgres)
+-- only: postgres
+
+-- Drop constraints so we can fix timestamps.
+ALTER TABLE reaction DROP CONSTRAINT reaction_message_fkey;
+ALTER TABLE message DROP CONSTRAINT message_pkey;
+
+-- Add part index to message and fix the hacky timestamps
+ALTER TABLE message ADD COLUMN part_index INTEGER;
+UPDATE message
+    SET timestamp=CASE WHEN timestamp > 1500000000000000 THEN timestamp / 1000 ELSE timestamp END,
+        part_index=CASE WHEN timestamp > 1500000000000000 THEN timestamp % 1000 ELSE 0 END;
+ALTER TABLE message ALTER COLUMN part_index SET NOT NULL;
+ALTER TABLE reaction ADD COLUMN _part_index INTEGER NOT NULL DEFAULT 0;
+
+-- Re-add the dropped constraints (but with part index and no chat)
+ALTER TABLE message ADD PRIMARY KEY (sender, timestamp, part_index, signal_receiver);
+ALTER TABLE message DROP CONSTRAINT message_signal_chat_id_signal_receiver_fkey;
+ALTER TABLE message ADD CONSTRAINT message_portal_fkey
+    FOREIGN KEY (signal_chat_id, signal_receiver)
+        REFERENCES portal (chat_id, receiver)
+        ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE reaction ADD CONSTRAINT reaction_message_fkey FOREIGN KEY (msg_author, msg_timestamp, _part_index, signal_receiver)
+    REFERENCES message (sender, timestamp, part_index, signal_receiver) ON DELETE CASCADE ON UPDATE CASCADE;
+-- Also update the reaction primary key
+ALTER TABLE reaction DROP CONSTRAINT reaction_pkey;
+ALTER TABLE reaction ADD PRIMARY KEY (author, msg_author, msg_timestamp, signal_receiver);
+
+-- Change unique constraint from (mxid, mx_room) to just mxid.
+ALTER TABLE message DROP CONSTRAINT message_mxid_mx_room_key;
+ALTER TABLE message ADD CONSTRAINT message_mxid_unique UNIQUE (mxid);
+ALTER TABLE reaction DROP CONSTRAINT reaction_mxid_mx_room_key;
+ALTER TABLE reaction ADD CONSTRAINT reaction_mxid_unique UNIQUE (mxid);
+
+CREATE TABLE lost_portals (
+    mxid     TEXT PRIMARY KEY,
+    chat_id  TEXT,
+    receiver TEXT
+);
+INSERT INTO lost_portals SELECT mxid, chat_id, receiver FROM portal WHERE mxid<>'';
+
+-- Make mxid column unique (requires using nulls for missing values)
+UPDATE portal SET mxid=NULL WHERE mxid='';
+ALTER TABLE portal ADD CONSTRAINT portal_mxid_unique UNIQUE(mxid);
+-- Delete any portals that aren't associated with logged-in users.
+DELETE FROM portal WHERE receiver<>'' AND receiver NOT IN (SELECT username FROM "user" WHERE uuid IS NOT NULL);
+-- Change receiver to uuid instead of phone number, also add nil uuid for groups.
+UPDATE portal SET receiver=(SELECT uuid FROM "user" WHERE username=receiver) WHERE receiver<>'';
+UPDATE portal SET receiver='00000000-0000-0000-0000-000000000000' WHERE receiver='';
+-- Drop the foreign keys again to allow changing types (the ON UPDATE CASCADEs are needed for the above step)
+ALTER TABLE message DROP CONSTRAINT message_portal_fkey;
+ALTER TABLE reaction DROP CONSTRAINT reaction_message_fkey;
+ALTER TABLE portal ALTER COLUMN receiver TYPE uuid USING receiver::uuid;
+ALTER TABLE message ALTER COLUMN signal_receiver TYPE uuid USING signal_receiver::uuid;
+ALTER TABLE reaction ALTER COLUMN signal_receiver TYPE uuid USING signal_receiver::uuid;
+-- Re-add the dropped constraints again
+ALTER TABLE message ADD CONSTRAINT message_portal_fkey
+    FOREIGN KEY (signal_chat_id, signal_receiver)
+        REFERENCES portal (chat_id, receiver)
+        ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE reaction ADD CONSTRAINT reaction_message_fkey FOREIGN KEY (msg_author, msg_timestamp, _part_index, signal_receiver)
+    REFERENCES message (sender, timestamp, part_index, signal_receiver) ON DELETE CASCADE ON UPDATE CASCADE;
+-- Delete group v1 portal entries
+DELETE FROM portal WHERE chat_id NOT LIKE '________-____-____-____-____________' AND LENGTH(chat_id) <> 44;
+DELETE FROM lost_portals WHERE mxid IN (SELECT mxid FROM portal WHERE mxid<>'');
+
+-- Remove unnecessary nullables in portal
+UPDATE portal SET name='' WHERE name IS NULL;
+UPDATE portal SET topic='' WHERE topic IS NULL;
+UPDATE portal SET avatar_hash='' WHERE avatar_hash IS NULL;
+UPDATE portal SET avatar_url='' WHERE avatar_url IS NULL;
+UPDATE portal SET expiration_time=0 WHERE expiration_time IS NULL;
+UPDATE portal SET relay_user_id='' WHERE relay_user_id IS NULL;
+ALTER TABLE portal ALTER COLUMN name SET NOT NULL;
+ALTER TABLE portal ALTER COLUMN topic SET NOT NULL;
+ALTER TABLE portal ALTER COLUMN avatar_hash SET NOT NULL;
+ALTER TABLE portal ALTER COLUMN avatar_url SET NOT NULL;
+ALTER TABLE portal ALTER COLUMN expiration_time SET NOT NULL;
+ALTER TABLE portal ALTER COLUMN relay_user_id SET NOT NULL;
+
+-- Add unique constraint to custom_mxid
+UPDATE puppet SET custom_mxid=NULL WHERE custom_mxid='';
+ALTER TABLE puppet ADD CONSTRAINT puppet_custom_mxid_unique UNIQUE(custom_mxid);
+-- Remove unnecessary nullables in puppet
+UPDATE puppet SET name='' WHERE name IS NULL;
+UPDATE puppet SET avatar_hash='' WHERE avatar_hash IS NULL;
+UPDATE puppet SET avatar_url='' WHERE avatar_url IS NULL;
+UPDATE puppet SET access_token='' WHERE access_token IS NULL;
+ALTER TABLE puppet ALTER COLUMN name SET NOT NULL;
+ALTER TABLE puppet ALTER COLUMN avatar_hash SET NOT NULL;
+ALTER TABLE puppet ALTER COLUMN avatar_url SET NOT NULL;
+ALTER TABLE puppet ALTER COLUMN access_token SET NOT NULL;
+ALTER TABLE puppet ALTER COLUMN name_quality DROP DEFAULT;
+
+ALTER TABLE "user" ADD CONSTRAINT user_uuid_unique UNIQUE(uuid);
+ALTER TABLE "user" RENAME COLUMN username TO phone;
+
+-- Drop room_id from disappearing message primary key
+ALTER TABLE disappearing_message DROP CONSTRAINT disappearing_message_pkey;
+ALTER TABLE disappearing_message ADD PRIMARY KEY (mxid);
+-- Remove unnecessary nullables in disappearing_message
+ALTER TABLE disappearing_message ALTER COLUMN room_id SET NOT NULL;
+UPDATE disappearing_message SET expiration_seconds=0 WHERE expiration_seconds IS NULL;
+ALTER TABLE disappearing_message ALTER COLUMN expiration_seconds SET NOT NULL;

--- a/database/upgrades/17-refactor-sqlite.sql
+++ b/database/upgrades/17-refactor-sqlite.sql
@@ -1,0 +1,187 @@
+-- v17: Refactor types (SQLite)
+-- transaction: off
+-- only: sqlite
+
+-- This is separate from v16 so that postgres can run with transaction: on
+-- (split upgrades by dialect don't currently allow disabling transaction in only one dialect)
+
+PRAGMA foreign_keys = OFF;
+BEGIN;
+
+CREATE TABLE message_new (
+    sender     uuid    NOT NULL,
+    timestamp  BIGINT  NOT NULL,
+    part_index INTEGER NOT NULL,
+
+    signal_chat_id  TEXT NOT NULL,
+    signal_receiver TEXT NOT NULL,
+
+    mxid    TEXT NOT NULL,
+    mx_room TEXT NOT NULL,
+
+    PRIMARY KEY (sender, timestamp, part_index, signal_receiver),
+    CONSTRAINT message_portal_fkey FOREIGN KEY (signal_chat_id, signal_receiver) REFERENCES portal(chat_id, receiver) ON DELETE CASCADE ON UPDATE CASCADE,
+    FOREIGN KEY (sender) REFERENCES puppet(uuid) ON DELETE CASCADE,
+    CONSTRAINT message_mxid_unique UNIQUE (mxid)
+);
+
+CREATE TABLE reaction_new (
+    msg_author    uuid    NOT NULL,
+    msg_timestamp BIGINT  NOT NULL,
+    -- part_index is not used in reactions, but is required for the foreign key.
+    _part_index   INTEGER NOT NULL DEFAULT 0,
+
+    author uuid NOT NULL,
+    emoji  TEXT NOT NULL,
+
+    signal_chat_id  TEXT NOT NULL,
+    signal_receiver TEXT NOT NULL,
+
+    mxid    TEXT NOT NULL,
+    mx_room TEXT NOT NULL,
+
+    PRIMARY KEY (msg_author, msg_timestamp, author, signal_receiver),
+    CONSTRAINT reaction_message_fkey FOREIGN KEY (msg_author, msg_timestamp, _part_index, signal_receiver)
+        REFERENCES message (sender, timestamp, part_index, signal_receiver) ON DELETE CASCADE ON UPDATE CASCADE,
+    FOREIGN KEY (author) REFERENCES puppet(uuid) ON DELETE CASCADE,
+    CONSTRAINT reaction_mxid_unique UNIQUE (mxid)
+);
+
+
+INSERT INTO message_new
+SELECT sender,
+       CASE WHEN timestamp > 1500000000000000 THEN timestamp / 1000 ELSE timestamp END,
+       CASE WHEN timestamp > 1500000000000000 THEN timestamp % 1000 ELSE 0 END,
+       COALESCE(signal_chat_id, ''),
+       COALESCE(signal_receiver, ''),
+       mxid,
+       mx_room
+FROM message;
+
+INSERT INTO reaction_new
+SELECT msg_author,
+       msg_timestamp,
+       0, -- _part_index
+       author,
+       emoji,
+       COALESCE(signal_chat_id, ''),
+       COALESCE(signal_receiver, ''),
+       mxid,
+       mx_room
+FROM reaction;
+
+DROP TABLE message;
+DROP TABLE reaction;
+ALTER TABLE message_new RENAME TO message;
+ALTER TABLE reaction_new RENAME TO reaction;
+
+PRAGMA foreign_key_check;
+COMMIT;
+
+PRAGMA foreign_keys = ON;
+
+BEGIN;
+CREATE TABLE lost_portals (
+    mxid     TEXT PRIMARY KEY,
+    chat_id  TEXT,
+    receiver TEXT
+);
+INSERT INTO lost_portals SELECT mxid, chat_id, receiver FROM portal WHERE mxid<>'';
+DELETE FROM portal WHERE receiver<>'' AND receiver NOT IN (SELECT username FROM "user" WHERE uuid<>'');
+UPDATE portal SET receiver=(SELECT uuid FROM "user" WHERE username=receiver) WHERE receiver<>'';
+UPDATE portal SET receiver='00000000-0000-0000-0000-000000000000' WHERE receiver='';
+DELETE FROM portal WHERE chat_id NOT LIKE '________-____-____-____-____________' AND LENGTH(chat_id) <> 44;
+DELETE FROM lost_portals WHERE mxid IN (SELECT mxid FROM portal WHERE mxid<>'');
+COMMIT;
+
+PRAGMA foreign_keys = OFF;
+
+BEGIN;
+
+CREATE TABLE portal_new (
+    chat_id     TEXT    NOT NULL,
+    receiver    uuid    NOT NULL,
+    mxid        TEXT,
+    name        TEXT    NOT NULL,
+    topic       TEXT    NOT NULL,
+    encrypted   BOOLEAN NOT NULL DEFAULT false,
+    avatar_hash TEXT    NOT NULL,
+    avatar_url  TEXT    NOT NULL,
+    name_set    BOOLEAN NOT NULL DEFAULT false,
+    avatar_set  BOOLEAN NOT NULL DEFAULT false,
+    revision    INTEGER NOT NULL DEFAULT 0,
+
+    expiration_time BIGINT NOT NULL,
+    relay_user_id   TEXT   NOT NULL,
+
+    PRIMARY KEY (chat_id, receiver),
+    CONSTRAINT portal_mxid_unique UNIQUE(mxid)
+);
+
+INSERT INTO portal_new
+    SELECT chat_id, receiver, CASE WHEN mxid='' THEN NULL ELSE mxid END,
+           COALESCE(name, ''), COALESCE(topic, ''), encrypted, COALESCE(avatar_hash, ''), COALESCE(avatar_url, ''),
+           name_set, avatar_set, revision, COALESCE(expiration_time, 0), COALESCE(relay_user_id, '')
+    FROM portal;
+DROP TABLE portal;
+ALTER TABLE portal_new RENAME TO portal;
+
+CREATE TABLE puppet_new (
+    uuid         uuid    PRIMARY KEY,
+    number       TEXT    UNIQUE,
+    name         TEXT    NOT NULL,
+    name_quality INTEGER NOT NULL,
+    avatar_hash  TEXT    NOT NULL,
+    avatar_url   TEXT    NOT NULL,
+    name_set     BOOLEAN NOT NULL DEFAULT false,
+    avatar_set   BOOLEAN NOT NULL DEFAULT false,
+
+    is_registered    BOOLEAN NOT NULL DEFAULT false,
+    contact_info_set BOOLEAN NOT NULL DEFAULT false,
+
+    custom_mxid  TEXT,
+    access_token TEXT NOT NULL,
+
+    CONSTRAINT puppet_custom_mxid_unique UNIQUE(custom_mxid)
+);
+
+INSERT INTO puppet_new
+    SELECT uuid, number, COALESCE(name, ''), COALESCE(name_quality, 0), COALESCE(avatar_hash, ''),
+        COALESCE(avatar_url, ''), name_set, avatar_set, is_registered, contact_info_set,
+        CASE WHEN custom_mxid='' THEN NULL ELSE custom_mxid END, COALESCE(access_token, '')
+    FROM puppet;
+DROP TABLE puppet;
+ALTER TABLE puppet_new RENAME TO puppet;
+
+CREATE TABLE user_new (
+    mxid  TEXT PRIMARY KEY,
+    uuid  uuid,
+    phone TEXT,
+
+    management_room TEXT,
+
+    CONSTRAINT user_uuid_unique UNIQUE(uuid)
+);
+
+INSERT INTO user_new
+    SELECT mxid, uuid, username, management_room
+    FROM user;
+DROP TABLE user;
+ALTER TABLE user_new RENAME TO user;
+
+CREATE TABLE disappearing_message_new (
+    mxid                TEXT   NOT NULL PRIMARY KEY,
+    room_id             TEXT   NOT NULL,
+    expiration_seconds  BIGINT NOT NULL,
+    expiration_ts       BIGINT
+);
+
+INSERT INTO disappearing_message_new
+    SELECT mxid, room_id, COALESCE(expiration_seconds, 0), expiration_ts
+    FROM disappearing_message;
+DROP TABLE disappearing_message;
+ALTER TABLE disappearing_message_new RENAME TO disappearing_message;
+
+PRAGMA foreign_key_check;
+COMMIT;
+PRAGMA foreign_keys = ON;

--- a/database/user.go
+++ b/database/user.go
@@ -1,5 +1,5 @@
 // mautrix-signal - A Matrix-signal puppeting bridge.
-// Copyright (C) 2023 Scott Weber
+// Copyright (C) 2023 Scott Weber, Tulir Asokan
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by
@@ -17,124 +17,86 @@
 package database
 
 import (
+	"context"
 	"database/sql"
 
-	"go.mau.fi/util/dbutil"
-	log "maunium.net/go/maulogger/v2"
+	"github.com/google/uuid"
 	"maunium.net/go/mautrix/id"
+
+	"go.mau.fi/util/dbutil"
+)
+
+const (
+	getUserByMXIDQuery       = `SELECT mxid, phone, uuid, management_room FROM "user" WHERE mxid=$1`
+	getUserByPhoneQuery      = `SELECT mxid, phone, uuid, management_room FROM "user" WHERE phone=$1`
+	getUserByUUIDQuery       = `SELECT mxid, phone, uuid, management_room FROM "user" WHERE uuid=$1`
+	getAllLoggedInUsersQuery = `SELECT mxid, phone, uuid, management_room FROM "user" WHERE phone IS NOT NULL`
+	insertUserQuery          = `INSERT INTO "user" (mxid, phone, uuid, management_room) VALUES ($1, $2, $3, $4)`
+	updateUserQuery          = `UPDATE "user" SET phone=$2, uuid=$3, management_room=$4 WHERE mxid=$1`
 )
 
 type UserQuery struct {
-	db  *Database
-	log log.Logger
-}
-
-func (uq *UserQuery) New() *User {
-	return &User{
-		db:  uq.db,
-		log: uq.log,
-	}
+	*dbutil.QueryHelper[*User]
 }
 
 type User struct {
-	db  *Database
-	log log.Logger
+	qh *dbutil.QueryHelper[*User]
 
 	MXID           id.UserID
 	SignalUsername string
-	SignalID       string
+	SignalID       uuid.UUID
 	ManagementRoom id.RoomID
 }
 
+func newUser(qh *dbutil.QueryHelper[*User]) *User {
+	return &User{qh: qh}
+}
+
+func (uq *UserQuery) GetByMXID(ctx context.Context, mxid id.UserID) (*User, error) {
+	return uq.QueryOne(ctx, getUserByMXIDQuery, mxid)
+}
+
+func (uq *UserQuery) GetByPhone(ctx context.Context, phone string) (*User, error) {
+	return uq.QueryOne(ctx, getUserByPhoneQuery, phone)
+}
+
+func (uq *UserQuery) GetBySignalID(ctx context.Context, uuid uuid.UUID) (*User, error) {
+	return uq.QueryOne(ctx, getUserByUUIDQuery, uuid)
+}
+
+func (uq *UserQuery) GetAllLoggedIn(ctx context.Context) ([]*User, error) {
+	return uq.QueryMany(ctx, getAllLoggedInUsersQuery)
+}
+
 func (u *User) sqlVariables() []any {
-	var username, signalID, managementRoom *string
-	if u.SignalUsername != "" {
-		username = &u.SignalUsername
-	}
-	if u.SignalID != "" {
-		signalID = &u.SignalID
-	}
-	if u.ManagementRoom != "" {
-		managementRoom = (*string)(&u.ManagementRoom)
-	}
-	return []any{u.MXID, username, signalID, managementRoom}
+	var nu uuid.NullUUID
+	nu.UUID = u.SignalID
+	nu.Valid = u.SignalID != uuid.Nil
+	return []any{u.MXID, dbutil.StrPtr(u.SignalUsername), nu, dbutil.StrPtr(u.ManagementRoom)}
 }
 
-func (u *User) Insert() error {
-	q := `INSERT INTO "user" (mxid, username, uuid, management_room) VALUES ($1, $2, $3, $4)`
-	_, err := u.db.Exec(q, u.sqlVariables()...)
-	return err
+func (u *User) Insert(ctx context.Context) error {
+	return u.qh.Exec(ctx, insertUserQuery, u.sqlVariables()...)
 }
 
-func (u *User) Update() error {
-	q := `UPDATE "user" SET username=$2, uuid=$3, management_room=$4 WHERE mxid=$1`
-	_, err := u.db.Exec(q, u.sqlVariables()...)
-	return err
+func (u *User) Update(ctx context.Context) error {
+	return u.qh.Exec(ctx, updateUserQuery, u.sqlVariables()...)
 }
 
-func (u *User) Scan(row dbutil.Scannable) *User {
-	var username, managementRoom, signalID sql.NullString
+func (u *User) Scan(row dbutil.Scannable) (*User, error) {
+	var phone, managementRoom sql.NullString
+	var signalID uuid.NullUUID
 	err := row.Scan(
 		&u.MXID,
-		&username,
+		&phone,
 		&signalID,
-		&managementRoom,
+		&u.ManagementRoom,
 	)
 	if err != nil {
-		if err != sql.ErrNoRows {
-			u.log.Errorln("Database scan failed:", err)
-		}
-		return nil
+		return nil, err
 	}
-	u.SignalUsername = username.String
-	u.SignalID = signalID.String
+	u.SignalUsername = phone.String
+	u.SignalID = signalID.UUID
 	u.ManagementRoom = id.RoomID(managementRoom.String)
-	return u
-}
-
-func (uq *UserQuery) GetByMXID(mxid id.UserID) *User {
-	q := `SELECT mxid, username, uuid, management_room FROM "user" WHERE mxid=$1`
-	row := uq.db.QueryRow(q, mxid)
-	if row == nil {
-		return nil
-	}
-	return uq.New().Scan(row)
-}
-
-func (uq *UserQuery) GetByUsername(username string) *User {
-	q := `SELECT mxid, username, uuid, management_room FROM "user" WHERE username=$1`
-	row := uq.db.QueryRow(q, username)
-	if row == nil {
-		return nil
-	}
-	return uq.New().Scan(row)
-}
-
-func (uq *UserQuery) GetBySignalID(uuid string) *User {
-	q := `SELECT mxid, username, uuid, management_room FROM "user" WHERE uuid=$1`
-	row := uq.db.QueryRow(q, uuid)
-	if row == nil {
-		return nil
-	}
-	return uq.New().Scan(row)
-}
-
-func (uq *UserQuery) AllLoggedIn() []*User {
-	q := `SELECT mxid, username, uuid, management_room FROM "user" WHERE username IS NOT NULL`
-	rows, err := uq.db.Query(q)
-	if err != nil {
-		uq.log.Errorln("Database query failed:", err)
-		return nil
-	}
-	defer rows.Close()
-
-	var users []*User
-	for rows.Next() {
-		u := uq.New().Scan(rows)
-		if u == nil {
-			continue
-		}
-		users = append(users, u)
-	}
-	return users
+	return u, nil
 }

--- a/database/user.go
+++ b/database/user.go
@@ -21,9 +21,8 @@ import (
 	"database/sql"
 
 	"github.com/google/uuid"
-	"maunium.net/go/mautrix/id"
-
 	"go.mau.fi/util/dbutil"
+	"maunium.net/go/mautrix/id"
 )
 
 const (

--- a/database/user.go
+++ b/database/user.go
@@ -90,7 +90,7 @@ func (u *User) Scan(row dbutil.Scannable) (*User, error) {
 		&u.MXID,
 		&phone,
 		&signalID,
-		&u.ManagementRoom,
+		&managementRoom,
 	)
 	if err != nil {
 		return nil, err

--- a/main.go
+++ b/main.go
@@ -25,15 +25,14 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/rs/zerolog"
+	"go.mau.fi/util/configupgrade"
+	"go.mau.fi/util/dbutil"
 	"maunium.net/go/mautrix"
 	"maunium.net/go/mautrix/bridge"
 	"maunium.net/go/mautrix/bridge/commands"
 	"maunium.net/go/mautrix/event"
 	"maunium.net/go/mautrix/format"
 	"maunium.net/go/mautrix/id"
-
-	"go.mau.fi/util/configupgrade"
-	"go.mau.fi/util/dbutil"
 
 	"go.mau.fi/mautrix-signal/config"
 	"go.mau.fi/mautrix-signal/database"

--- a/msgconv/matrixfmt/convert_test.go
+++ b/msgconv/matrixfmt/convert_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"maunium.net/go/mautrix/event"
 	"maunium.net/go/mautrix/id"
@@ -13,11 +14,11 @@ import (
 )
 
 var formatParams = &matrixfmt.HTMLParser{
-	GetUUIDFromMXID: func(id id.UserID) string {
+	GetUUIDFromMXID: func(id id.UserID) uuid.UUID {
 		if id.Homeserver() == "signal" {
-			return id.Localpart()
+			return uuid.MustParse(id.Localpart())
 		}
-		return ""
+		return uuid.Nil
 	},
 }
 

--- a/msgconv/matrixfmt/html.go
+++ b/msgconv/matrixfmt/html.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/google/uuid"
 	"golang.org/x/exp/slices"
 	"golang.org/x/net/html"
 	"maunium.net/go/mautrix/event"
@@ -223,7 +224,7 @@ func (ctx Context) WithWhitespace() Context {
 
 // HTMLParser is a somewhat customizable Matrix HTML parser.
 type HTMLParser struct {
-	GetUUIDFromMXID func(id.UserID) string
+	GetUUIDFromMXID func(id.UserID) uuid.UUID
 }
 
 // TaggedString is a string that also contains a HTML tag.
@@ -355,8 +356,8 @@ func (parser *HTMLParser) linkToString(node *html.Node, ctx Context) *EntityStri
 			// Mention not allowed, use name as-is
 			return str
 		}
-		uuid := parser.GetUUIDFromMXID(mxid)
-		if uuid == "" {
+		u := parser.GetUUIDFromMXID(mxid)
+		if u == uuid.Nil {
 			// Don't include the link for mentions of non-Signal users, the name is enough
 			return str
 		}
@@ -365,7 +366,7 @@ func (parser *HTMLParser) linkToString(node *html.Node, ctx Context) *EntityStri
 				MXID: mxid,
 				Name: str.String.String(),
 			},
-			UUID: uuid,
+			UUID: u,
 		})
 	}
 	if str.String.String() == href {

--- a/msgconv/signalfmt/convert_test.go
+++ b/msgconv/signalfmt/convert_test.go
@@ -29,11 +29,11 @@ import (
 	signalpb "go.mau.fi/mautrix-signal/pkg/signalmeow/protobuf"
 )
 
-var realUser = uuid.NewString()
+var realUser = uuid.New()
 
 func TestParse(t *testing.T) {
 	formatParams := &signalfmt.FormatParams{
-		GetUserInfo: func(uuid string) signalfmt.UserInfo {
+		GetUserInfo: func(uuid uuid.UUID) signalfmt.UserInfo {
 			if uuid == realUser {
 				return signalfmt.UserInfo{
 					MXID: "@test:example.com",
@@ -41,7 +41,7 @@ func TestParse(t *testing.T) {
 				}
 			} else {
 				return signalfmt.UserInfo{
-					MXID: id.UserID("@signal_" + uuid + ":example.com"),
+					MXID: id.UserID("@signal_" + uuid.String() + ":example.com"),
 					Name: "Signal User",
 				}
 			}
@@ -79,7 +79,7 @@ func TestParse(t *testing.T) {
 				Start:  proto.Uint32(6),
 				Length: proto.Uint32(1),
 				AssociatedValue: &signalpb.BodyRange_MentionAci{
-					MentionAci: realUser,
+					MentionAci: realUser.String(),
 				},
 			}},
 			body: "Hello Matrix User",

--- a/msgconv/signalfmt/tags.go
+++ b/msgconv/signalfmt/tags.go
@@ -19,6 +19,8 @@ package signalfmt
 import (
 	"fmt"
 
+	"github.com/google/uuid"
+
 	signalpb "go.mau.fi/mautrix-signal/pkg/signalmeow/protobuf"
 )
 
@@ -30,7 +32,7 @@ type BodyRangeValue interface {
 
 type Mention struct {
 	UserInfo
-	UUID string
+	UUID uuid.UUID
 }
 
 func (m Mention) String() string {
@@ -39,7 +41,7 @@ func (m Mention) String() string {
 
 func (m Mention) Proto() signalpb.BodyRangeAssociatedValue {
 	return &signalpb.BodyRange_MentionAci{
-		MentionAci: m.UUID,
+		MentionAci: m.UUID.String(),
 	}
 }
 

--- a/pkg/signalmeow/events/message.go
+++ b/pkg/signalmeow/events/message.go
@@ -1,0 +1,16 @@
+package events
+
+import (
+	"github.com/google/uuid"
+
+	signalpb "go.mau.fi/mautrix-signal/pkg/signalmeow/protobuf"
+)
+
+type MessageInfo struct {
+	Sender uuid.UUID
+	Chat   string
+}
+
+type Receipt struct {
+	*signalpb.ReceiptMessage
+}

--- a/pkg/signalmeow/incoming_messages.go
+++ b/pkg/signalmeow/incoming_messages.go
@@ -28,6 +28,7 @@ type IncomingSignalMessageBase struct {
 	RecipientUUID string                          // Usually our UUID, unless this is a message we sent on another device
 	GroupID       *GroupIdentifier                // Unique identifier for the group chat, or nil for 1:1 chats
 	Timestamp     uint64                          // With SenderUUID, treated as a unique identifier for a specific Signal message
+	PartIndex     int                             //
 	Quote         *IncomingSignalMessageQuoteData // If this message is a quote (reply), this will be non-nil
 	ExpiresIn     int64                           // If this message is ephemeral, this will be non-zero (in seconds)
 }

--- a/pkg/signalmeow/receiving.go
+++ b/pkg/signalmeow/receiving.go
@@ -828,7 +828,7 @@ func incomingDataMessage(ctx context.Context, device *Device, dataMessage *signa
 		expiresIn = int64(dataMessage.GetExpireTimer())
 	}
 
-	tsIndex := 0
+	partIndex := 0
 	// If there's attachements, handle them (one at a time for now)
 	if dataMessage.Attachments != nil {
 		for index, attachmentPointer := range dataMessage.Attachments {
@@ -837,19 +837,14 @@ func incomingDataMessage(ctx context.Context, device *Device, dataMessage *signa
 				zlog.Err(err).Msg("fetchAndDecryptAttachment error")
 				continue
 			}
-			// TODO: this is a hack to make sure each attachment has a unique timestamp
-			// this allows us to associate up to 999 attachments with a single Signal message
-			var timestamp uint64 = dataMessage.GetTimestamp()
-			if index > 0 {
-				timestamp = (dataMessage.GetTimestamp() * 1000) + uint64(index)
-			}
 			// TODO: right now this will be one message per image, each with the same caption
 			incomingMessage := IncomingSignalMessageAttachment{
 				IncomingSignalMessageBase: IncomingSignalMessageBase{
 					SenderUUID:    senderUUID,
 					RecipientUUID: recipientUUID,
 					GroupID:       gidPointer,
-					Timestamp:     timestamp,
+					Timestamp:     dataMessage.GetTimestamp(),
+					PartIndex:     partIndex,
 					Quote:         quoteData,
 					ExpiresIn:     expiresIn,
 				},
@@ -861,33 +856,31 @@ func incomingDataMessage(ctx context.Context, device *Device, dataMessage *signa
 				Height:      attachmentPointer.GetHeight(),
 				BlurHash:    attachmentPointer.GetBlurHash(),
 			}
+			partIndex++
 			if HackyCaptionToggle && index == 0 {
 				incomingMessage.Caption = dataMessage.GetBody()
 				incomingMessage.CaptionRanges = dataMessage.GetBodyRanges()
 			}
 			incomingMessages = append(incomingMessages, incomingMessage)
 		}
-		tsIndex += len(dataMessage.Attachments)
 	}
 
 	// If there's a body but no attachments, pass along as a text message
 	if dataMessage.Body != nil && (dataMessage.Attachments == nil || !HackyCaptionToggle) {
-		timestamp := dataMessage.GetTimestamp()
-		if tsIndex != 0 {
-			timestamp = (dataMessage.GetTimestamp() * 1000) + uint64(tsIndex+1)
-		}
 		incomingMessage := IncomingSignalMessageText{
 			IncomingSignalMessageBase: IncomingSignalMessageBase{
 				SenderUUID:    senderUUID,
 				RecipientUUID: recipientUUID,
 				GroupID:       gidPointer,
-				Timestamp:     timestamp,
+				Timestamp:     dataMessage.GetTimestamp(),
+				PartIndex:     partIndex,
 				Quote:         quoteData,
 				ExpiresIn:     expiresIn,
 			},
 			Content:       dataMessage.GetBody(),
 			ContentRanges: dataMessage.GetBodyRanges(),
 		}
+		partIndex++
 		incomingMessages = append(incomingMessages, incomingMessage)
 	}
 
@@ -903,6 +896,7 @@ func incomingDataMessage(ctx context.Context, device *Device, dataMessage *signa
 					RecipientUUID: recipientUUID,
 					GroupID:       gidPointer,
 					Timestamp:     dataMessage.GetTimestamp(),
+					PartIndex:     partIndex,
 					Quote:         quoteData,
 					ExpiresIn:     expiresIn,
 				},
@@ -914,6 +908,7 @@ func incomingDataMessage(ctx context.Context, device *Device, dataMessage *signa
 				Emoji:       dataMessage.GetSticker().GetEmoji(),
 			}
 			incomingMessages = append(incomingMessages, incomingMessage)
+			partIndex++
 		}
 	}
 
@@ -978,6 +973,7 @@ func incomingDataMessage(ctx context.Context, device *Device, dataMessage *signa
 					RecipientUUID: recipientUUID,
 					GroupID:       gidPointer,
 					Timestamp:     dataMessage.GetTimestamp(),
+					PartIndex:     partIndex,
 				},
 				DisplayName:  contactCard.GetName().GetDisplayName(),
 				Organization: contactCard.GetOrganization(),
@@ -1017,6 +1013,7 @@ func incomingDataMessage(ctx context.Context, device *Device, dataMessage *signa
 				addressString := strings.Join(addressParts, ", ")
 				incomingMessage.Addresses = append(incomingMessage.Addresses, addressString)
 			}
+			partIndex++
 			incomingMessages = append(incomingMessages, incomingMessage)
 		}
 	}

--- a/portal.go
+++ b/portal.go
@@ -1069,8 +1069,12 @@ func (portal *Portal) addSignalQuote(ctx context.Context, content *event.Message
 	if quote == nil {
 		return
 	}
+	quotedSender, err := uuid.Parse(quote.QuotedSender)
+	if err != nil {
+		return
+	}
 	originalMessage, err := portal.bridge.DB.Message.GetBySignalID(
-		ctx, uuid.MustParse(quote.QuotedSender), quote.QuotedTimestamp, 0, portal.Receiver,
+		ctx, quotedSender, quote.QuotedTimestamp, 0, portal.Receiver,
 	)
 	if err != nil {
 		zerolog.Ctx(ctx).Err(err).Str("quoted_sender", quote.QuotedSender).Uint64("quoted_timestamp", quote.QuotedTimestamp).Msg("Failed to get quoted message from database")

--- a/portal.go
+++ b/portal.go
@@ -1106,7 +1106,7 @@ func (portal *Portal) handleSignalTextMessage(ctx context.Context, portalMessage
 	msg := (portalMessage.message).(signalmeow.IncomingSignalMessageText)
 	content := signalfmt.Parse(msg.Content, msg.ContentRanges, signalFormatParams)
 	portal.addSignalQuote(ctx, content, msg.Quote)
-	resp, err := portal.sendMatrixMessage(intent, event.EventMessage, content, nil, 0)
+	resp, err := portal.sendMatrixMessage(intent, event.EventMessage, content, nil, int64(timestamp))
 	if err != nil {
 		return err
 	}
@@ -1139,7 +1139,7 @@ func (portal *Portal) handleSignalStickerMessage(ctx context.Context, portalMess
 		portal.log.Error().Err(err).Msg("Failed to upload media")
 	}
 
-	resp, err := portal.sendMatrixMessage(intent, event.EventSticker, content, nil, 0)
+	resp, err := portal.sendMatrixMessage(intent, event.EventSticker, content, nil, int64(timestamp))
 	if err != nil {
 		return err
 	}
@@ -1433,7 +1433,7 @@ func (portal *Portal) handleSignalAttachmentMessage(ctx context.Context, portalM
 		portal.log.Error().Err(err).Msg(failureMessage)
 		portal.MainIntent().SendNotice(portal.MXID, failureMessage)
 	}
-	resp, err := portal.sendMatrixMessage(intent, event.EventMessage, content, nil, 0)
+	resp, err := portal.sendMatrixMessage(intent, event.EventMessage, content, nil, int64(timestamp))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
* Change most columns to `NOT NULL`, including primary keys (because SQLite).
* Change columns only storing signal user IDs (portal receiver, message sender, user uuid) to use the `uuid` type instead of `TEXT`.
* Drop chat ID from message table primary key.
* Add part index to message table to replace timestamp hack for storing multiple parts of the same message.
* Change query wrappers to use new QureyHelper struct in dbutil, and pass contexts and errors everywhere.

As a part of changing the portal receiver from phone number to uuid, old portals whose receiver isn't logged in anymore may be discarded. The discarded portals will be stored in the lost_portals table for cleanup or recovery.