### PR TITLE
logging: use structured logging in more places

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module go.mau.fi/mautrix-signal
 go 1.20
 
 require (
+	github.com/beeper/libserv v0.0.0-20231231163024-8eba5b0c509d
 	github.com/google/uuid v1.5.0
 	github.com/gorilla/mux v1.8.0
 	github.com/lib/pq v1.10.9
@@ -38,6 +39,7 @@ require (
 	github.com/prometheus/client_model v0.5.0 // indirect
 	github.com/prometheus/common v0.45.0 // indirect
 	github.com/prometheus/procfs v0.12.0 // indirect
+	github.com/rs/xid v1.5.0 // indirect
 	github.com/tidwall/gjson v1.17.0 // indirect
 	github.com/tidwall/match v1.1.1 // indirect
 	github.com/tidwall/pretty v1.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,6 @@
 github.com/DATA-DOG/go-sqlmock v1.5.1 h1:FK6RCIUSfmbnI/imIICmboyQBkOckutaa6R5YYlLZyo=
+github.com/beeper/libserv v0.0.0-20231231163024-8eba5b0c509d h1:CSrg1zpAEMXK3VIUx5deRT6YMMX3Kd8jDkiUmB1uoWw=
+github.com/beeper/libserv v0.0.0-20231231163024-8eba5b0c509d/go.mod h1:b9FFm9y4mEm36G8ytVmS1vkNzJa0KepmcdVY+qf7qRU=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/cespare/xxhash/v2 v2.2.0 h1:DC2CZ1Ep5Y4k3ZQ899DldepgrayRUGE6BBZ/cd9Cj44=
@@ -44,6 +46,7 @@ github.com/prometheus/common v0.45.0/go.mod h1:YJmSTw9BoKxJplESWWxlbyttQR4uaEcGy
 github.com/prometheus/procfs v0.12.0 h1:jluTpSng7V9hY0O2R9DzzJHYb2xULk9VTR1V1R/k6Bo=
 github.com/prometheus/procfs v0.12.0/go.mod h1:pcuDEFsWDnvcgNzo4EEweacyhjeA9Zk3cnaOZAZEfOo=
 github.com/rogpeppe/go-internal v1.10.0 h1:TMyTOH3F/DB16zRVcYyreMH6GnZZrwQVAoYjRBZyWFQ=
+github.com/rs/xid v1.5.0 h1:mKX4bl4iPYJtEIxp6CYiUuLQ/8DYMoz0PUdtGgMFRVc=
 github.com/rs/xid v1.5.0/go.mod h1:trrq9SKmegXys3aeAKXMUTdJsYXVwGY3RLcfgqegfbg=
 github.com/rs/zerolog v1.31.0 h1:FcTR3NnLWW+NnTwwhFWiJSZr4ECLpqCm6QsEnyvbV4A=
 github.com/rs/zerolog v1.31.0/go.mod h1:/7mN4D5sKwJLZQ2b/znpjC3/GQWY/xaDXUM0kKWRHss=

--- a/messagetracking.go
+++ b/messagetracking.go
@@ -23,6 +23,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/rs/zerolog"
 	"maunium.net/go/mautrix"
 	"maunium.net/go/mautrix/bridge/status"
 	"maunium.net/go/mautrix/event"
@@ -106,13 +107,28 @@ func errorToStatusReason(err error) (reason event.MessageStatusReason, status ev
 	}
 }
 
-func (portal *Portal) sendErrorMessage(evt *event.Event, err error, msgType string, confirmed bool, editID id.EventID) id.EventID {
+func (portal *Portal) sendErrorMessage(evt *event.Event, err error, confirmed bool, editID id.EventID) id.EventID {
 	if !portal.bridge.Config.Bridge.MessageErrorNotices {
 		return ""
 	}
 	certainty := "may not have been"
 	if confirmed {
 		certainty = "was not"
+	}
+	var msgType string
+	switch evt.Type {
+	case event.EventMessage:
+		msgType = "message"
+	case event.EventReaction:
+		msgType = "reaction"
+	case event.EventRedaction:
+		msgType = "redaction"
+	//case TypeMSC3381PollResponse, TypeMSC3381V2PollResponse:
+	//	msgType = "poll response"
+	//case TypeMSC3381PollStart:
+	//	msgType = "poll start"
+	default:
+		msgType = "unknown event"
 	}
 	msg := fmt.Sprintf("\u26a0 Your %s %s bridged: %v", msgType, certainty, err)
 	if errors.Is(err, errMessageTakingLong) {
@@ -178,24 +194,9 @@ func (portal *Portal) sendDeliveryReceipt(eventID id.EventID) {
 }
 
 func (portal *Portal) sendMessageMetrics(evt *event.Event, err error, part string, ms *metricSender) {
-	var msgType string
-	switch evt.Type {
-	case event.EventMessage:
-		msgType = "message"
-	case event.EventReaction:
-		msgType = "reaction"
-	case event.EventRedaction:
-		msgType = "redaction"
-	//case TypeMSC3381PollResponse, TypeMSC3381V2PollResponse:
-	//	msgType = "poll response"
-	//case TypeMSC3381PollStart:
-	//	msgType = "poll start"
-	default:
-		msgType = "unknown event"
-	}
 	log := portal.log.With().
-		Str("part", part).
-		Str("msg_type", msgType).
+		Str("handling_step", part).
+		Str("event_type", evt.Type.String()).
 		Stringer("event_id", evt.ID).
 		Stringer("sender", evt.Sender).
 		Logger()
@@ -217,7 +218,7 @@ func (portal *Portal) sendMessageMetrics(evt *event.Event, err error, part strin
 		checkpointStatus := status.ReasonToCheckpointStatus(reason, statusCode)
 		portal.bridge.SendMessageCheckpoint(evt, status.MsgStepRemote, err, checkpointStatus, ms.getRetryNum())
 		if sendNotice {
-			ms.setNoticeID(portal.sendErrorMessage(evt, err, msgType, isCertain, ms.getNoticeID()))
+			ms.setNoticeID(portal.sendErrorMessage(evt, err, isCertain, ms.getNoticeID()))
 		}
 		portal.sendStatusEvent(origEvtID, evt.ID, err, nil)
 	} else {
@@ -236,7 +237,7 @@ func (portal *Portal) sendMessageMetrics(evt *event.Event, err error, part strin
 		}
 	}
 	if ms != nil {
-		portal.log.Debug().Stringer("timings", ms.timings).Msg("Timings for event")
+		portal.log.Debug().Object("timings", ms.timings).Msg("Timings for event")
 	}
 }
 
@@ -263,16 +264,18 @@ func niceRound(dur time.Duration) time.Duration {
 	}
 }
 
-func (mt *messageTimings) String() string {
-	mt.initReceive = niceRound(mt.initReceive)
-	mt.decrypt = niceRound(mt.decrypt)
-	mt.portalQueue = niceRound(mt.portalQueue)
-	mt.totalReceive = niceRound(mt.totalReceive)
-	mt.implicitRR = niceRound(mt.implicitRR)
-	mt.preproc = niceRound(mt.preproc)
-	mt.convert = niceRound(mt.convert)
-	mt.totalSend = niceRound(mt.totalSend)
-	return fmt.Sprintf("BRIDGE: receive: %s, decrypt: %s, queue: %s, total hs->portal: %s, implicit rr: %s -- PORTAL: preprocess: %s, convert: %s, total send: %s ", mt.initReceive, mt.decrypt, mt.implicitRR, mt.portalQueue, mt.totalReceive, mt.preproc, mt.convert, mt.totalSend)
+func (mt *messageTimings) MarshalZerologObject(evt *zerolog.Event) {
+	evt.
+		Dict("bridge", zerolog.Dict().
+			Str("init_receive", niceRound(mt.initReceive).String()).
+			Str("decrypt", niceRound(mt.decrypt).String()).
+			Str("queue", niceRound(mt.portalQueue).String()).
+			Str("total_hs_to_portal", niceRound(mt.totalReceive).String())).
+		Dict("portal", zerolog.Dict().
+			Str("implicit_rr", niceRound(mt.implicitRR).String()).
+			Str("preproc", niceRound(mt.preproc).String()).
+			Str("convert", niceRound(mt.convert).String()).
+			Str("total_send", niceRound(mt.totalSend).String()))
 }
 
 type metricSender struct {

--- a/msgconv/from-matrix.go
+++ b/msgconv/from-matrix.go
@@ -164,7 +164,7 @@ func (mc *MessageConverter) convertFileToSignal(ctx context.Context, evt *event.
 			return nil, fmt.Errorf("unsupported content type for sticker %s", mime)
 		}
 	}
-	att, err := signalmeow.UploadAttachment(mc.GetClient(ctx), data)
+	att, err := signalmeow.UploadAttachment(ctx, mc.GetClient(ctx), data)
 	if err != nil {
 		log.Err(err).Msg("Failed to upload file")
 		return nil, fmt.Errorf("failed to upload: %w", err)

--- a/msgconv/from-signal.go
+++ b/msgconv/from-signal.go
@@ -270,7 +270,7 @@ func (mc *MessageConverter) convertStickerToMatrix(ctx context.Context, sticker 
 }
 
 func (mc *MessageConverter) reuploadAttachment(ctx context.Context, att *signalpb.AttachmentPointer) (*ConvertedMessagePart, error) {
-	data, err := signalmeow.DownloadAttachment(att)
+	data, err := signalmeow.DownloadAttachment(ctx, att)
 	if err != nil {
 		return nil, fmt.Errorf("failed to download attachment: %w", err)
 	}

--- a/msgconv/urlpreview.go
+++ b/msgconv/urlpreview.go
@@ -128,7 +128,7 @@ func (mc *MessageConverter) convertURLPreviewToSignal(ctx context.Context, evt *
 					continue
 				}
 			}
-			uploaded, err := signalmeow.UploadAttachment(mc.GetClient(ctx), data)
+			uploaded, err := signalmeow.UploadAttachment(ctx, mc.GetClient(ctx), data)
 			if err != nil {
 				log.Err(err).Int("preview_index", i).Msg("Failed to reupload URL preview image")
 				continue

--- a/pkg/signalmeow/attachments.go
+++ b/pkg/signalmeow/attachments.go
@@ -29,7 +29,7 @@ import (
 	"math"
 	"net/http"
 
-	"github.com/rs/zerolog/log"
+	"github.com/rs/zerolog"
 	"go.mau.fi/util/random"
 
 	signalpb "go.mau.fi/mautrix-signal/pkg/signalmeow/protobuf"
@@ -108,6 +108,7 @@ type attachmentV3UploadAttributes struct {
 }
 
 func UploadAttachment(ctx context.Context, device *Device, body []byte) (*signalpb.AttachmentPointer, error) {
+	log := zerolog.Ctx(ctx)
 	keys := random.Bytes(64) // combined AES and MAC keys
 	plaintextLength := uint32(len(body))
 
@@ -208,10 +209,7 @@ func aesDecrypt(key, ciphertext []byte) ([]byte, error) {
 	}
 
 	if len(ciphertext)%aes.BlockSize != 0 {
-		log.Debug().
-			Int("length", len(ciphertext)%aes.BlockSize).
-			Msg("aesDecrypt ciphertext not multiple of AES blocksize")
-		return nil, errors.New("ciphertext not multiple of AES blocksize")
+		return nil, fmt.Errorf("ciphertext not multiple of AES blocksize (%d extra bytes)", len(ciphertext)%aes.BlockSize)
 	}
 
 	iv := ciphertext[:aes.BlockSize]

--- a/pkg/signalmeow/groups.go
+++ b/pkg/signalmeow/groups.go
@@ -48,7 +48,7 @@ const (
 )
 
 type GroupMember struct {
-	UserId           string
+	UserID           string
 	Role             GroupMemberRole
 	ProfileKey       libsignalgo.ProfileKey
 	JoinedAtRevision uint32
@@ -306,7 +306,7 @@ func decryptGroup(encryptedGroup *signalpb.Group, groupMasterKey SerializedGroup
 			return nil, err
 		}
 		decryptedGroup.Members = append(decryptedGroup.Members, &GroupMember{
-			UserId:           userID.String(),
+			UserID:           userID.String(),
 			ProfileKey:       *profileKey,
 			Role:             GroupMemberRole(member.Role),
 			JoinedAtRevision: member.JoinedAtRevision,
@@ -359,26 +359,6 @@ func decryptGroupAvatar(encryptedAvatar []byte, groupMasterKey SerializedGroupMa
 	decryptedImage := avatarBlob.GetAvatar()
 
 	return decryptedImage, nil
-}
-
-func printGroupMember(member *GroupMember) {
-	if member == nil {
-		zlog.Debug().Msg("GroupMember is nil")
-		return
-	}
-	zlog.Debug().Msgf("UserID: %v", member.UserId)
-	zlog.Debug().Msgf("ProfileKey: %v", member.ProfileKey)
-	zlog.Debug().Msgf("Role: %v", member.Role)
-	zlog.Debug().Msgf("JoinedAtRevision: %v", member.JoinedAtRevision)
-}
-func printGroup(group *Group) {
-	zlog.Debug().Msgf("GroupIdentifier: %v", group.GroupIdentifier)
-	zlog.Debug().Msgf("Title: %v", group.Title)
-	zlog.Debug().Msgf("AvatarPath: %v", group.AvatarPath)
-	zlog.Debug().Msgf("Members len: %v", len(group.Members))
-	for _, member := range group.Members {
-		printGroupMember(member)
-	}
 }
 
 func groupMetadataForDataMessage(group Group) *signalpb.GroupContextV2 {
@@ -442,7 +422,7 @@ func fetchGroupByID(ctx context.Context, d *Device, gid types.GroupIdentifier) (
 
 	// Store the profile keys in case they're new
 	for _, member := range group.Members {
-		err = d.ProfileKeyStore.StoreProfileKey(member.UserId, member.ProfileKey, ctx)
+		err = d.ProfileKeyStore.StoreProfileKey(member.UserID, member.ProfileKey, ctx)
 		if err != nil {
 			zlog.Err(err).Msg("DecryptGroup StoreProfileKey error")
 			//return nil, err
@@ -459,7 +439,7 @@ func fetchAndDecryptGroupAvatarImage(d *Device, path string, masterKey Serialize
 		Username: &username,
 		Password: &password,
 	}
-	zlog.Info().Msgf("Fetching group avatar from %v", path)
+	zlog.Info().Str("avatar_path", path).Msg("Fetching group avatar")
 	resp, err := web.SendHTTPRequest(http.MethodGet, path, opts)
 	if err != nil {
 		zlog.Err(err).Msg("error fetching group avatar")

--- a/pkg/signalmeow/keys.go
+++ b/pkg/signalmeow/keys.go
@@ -315,7 +315,7 @@ func FetchAndProcessPreKey(ctx context.Context, device *Device, theirUuid string
 		return err
 	}
 	var prekeyResponse prekeyResponse
-	err = web.DecodeHTTPResponseBody(&prekeyResponse, resp)
+	err = web.DecodeHTTPResponseBody(ctx, &prekeyResponse, resp)
 	if err != nil {
 		zlog.Err(err).Msg("Fetching prekeys, error with response body")
 		return err

--- a/pkg/signalmeow/profile.go
+++ b/pkg/signalmeow/profile.go
@@ -205,7 +205,9 @@ func fetchProfileByID(ctx context.Context, d *Device, signalID uuid.UUID) (*Prof
 	path := "/v1/profile/" + signalID.String()
 	useUnidentified := profileKeyVersion != nil && accessKey != nil
 	if useUnidentified {
-		zlog.Trace().Msgf("Using unidentified profile request with profileKeyVersion: %v", profileKeyVersion)
+		zlog.Trace().
+			Hex("profile_key_version", profileKeyVersion[:]).
+			Msg("Using unidentified profile request")
 		// Assuming we can just make the version bytes into a string
 		path += "/" + profileKeyVersion.String()
 	}
@@ -276,7 +278,7 @@ func fetchAndDecryptAvatarImage(d *Device, avatarPath string, profileKey *libsig
 		Username: &username,
 		Password: &password,
 	}
-	zlog.Info().Msgf("Fetching profile avatar from %v", avatarPath)
+	zlog.Info().Str("avatar_path", avatarPath).Msg("Fetching profile avatar")
 	resp, err := web.SendHTTPRequest(http.MethodGet, avatarPath, opts)
 	if err != nil {
 		zlog.Err(err).Msg("error fetching profile avatar")

--- a/pkg/signalmeow/provisioning.go
+++ b/pkg/signalmeow/provisioning.go
@@ -64,6 +64,21 @@ const (
 	StateProvisioningPreKeysRegistered
 )
 
+func (s ProvisioningState) String() string {
+	switch s {
+	case StateProvisioningError:
+		return "StateProvisioningError"
+	case StateProvisioningURLReceived:
+		return "StateProvisioningURLReceived"
+	case StateProvisioningDataReceived:
+		return "StateProvisioningDataReceived"
+	case StateProvisioningPreKeysRegistered:
+		return "StateProvisioningPreKeysRegistered"
+	default:
+		return fmt.Sprintf("ProvisioningState(%d)", s)
+	}
+}
+
 // Enum for the provisioningUrl, ProvisioningMessage, and error
 type ProvisioningResponse struct {
 	State            ProvisioningState
@@ -79,9 +94,9 @@ func PerformProvisioning(incomingCtx context.Context, deviceStore DeviceStore, d
 
 		ctx, cancel := context.WithTimeout(incomingCtx, 2*time.Minute)
 		defer cancel()
-		ws, err := openProvisioningWebsocket(ctx)
+		ws, resp, err := web.OpenWebsocket(ctx, web.WebsocketProvisioningPath)
 		if err != nil {
-			zlog.Err(err).Msg("openProvisioningWebsocket error")
+			zlog.Err(err).Any("resp", resp).Msg("error opening provisioning websocket")
 			c <- ProvisioningResponse{State: StateProvisioningError, Err: err}
 			return
 		}
@@ -219,15 +234,6 @@ func PerformProvisioning(incomingCtx context.Context, deviceStore DeviceStore, d
 	return c
 }
 
-func openProvisioningWebsocket(ctx context.Context) (*websocket.Conn, error) {
-	ws, resp, err := web.OpenWebsocket(ctx, web.WebsocketProvisioningPath)
-	if err != nil {
-		zlog.Err(err).Msgf("openWebsocket error, resp : %v", resp)
-		return nil, err
-	}
-	return ws, nil
-}
-
 // Returns the provisioningUrl and an error
 func startProvisioning(ctx context.Context, ws *websocket.Conn, provisioningCipher *ProvisioningCipher) (string, error) {
 	pubKey := provisioningCipher.GetPublicKey()
@@ -323,7 +329,7 @@ func confirmDevice(
 
 	ws, resp, err := web.OpenWebsocket(ctx, web.WebsocketPath)
 	if err != nil {
-		zlog.Err(err).Msgf("openWebsocket error, resp : %v", resp)
+		zlog.Err(err).Any("resp", resp).Msg("error opening websocket")
 		return nil, err
 	}
 	defer ws.Close(websocket.StatusInternalError, "Websocket StatusInternalError")
@@ -355,7 +361,7 @@ func confirmDevice(
 
 	jsonBytes, err := json.Marshal(data)
 	if err != nil {
-		zlog.Err(err).Msgf("failed to marshal json: %v", resp)
+		zlog.Err(err).Msg("failed to marshal JSON")
 		return nil, err
 	}
 
@@ -370,21 +376,21 @@ func confirmDevice(
 	}
 	err = wspb.Write(ctx, ws, message)
 	if err != nil {
-		zlog.Err(err).Msgf("failed on write %v", resp)
+		zlog.Err(err).Msg("failed on write protobuf data to websocket")
 		return nil, err
 	}
 
 	receivedMsg := &signalpb.WebSocketMessage{}
 	err = wspb.Read(ctx, ws, receivedMsg)
 	if err != nil {
-		zlog.Err(err).Msgf("failed to read after devices call: %v", resp)
+		zlog.Err(err).Msg("failed to read from websocket after devices call")
 		return nil, err
 	}
 
 	status := int(*receivedMsg.Response.Status)
 	if status < 200 || status >= 300 {
 		err := fmt.Errorf("problem with devices response - status: %d, message: %s", status, *receivedMsg.Response.Message)
-		zlog.Err(err).Msg("")
+		zlog.Err(err).Msg("non-200 status code from devices response")
 		return nil, err
 	}
 
@@ -392,7 +398,7 @@ func confirmDevice(
 	deviceResp := ConfirmDeviceResponse{}
 	err = json.Unmarshal(receivedMsg.Response.Body, &deviceResp)
 	if err != nil {
-		zlog.Err(err).Msgf("failed to unmarshal json: %v", receivedMsg.Response.Body)
+		zlog.Err(err).Msg("failed to unmarshal JSON")
 		return nil, err
 	}
 

--- a/pkg/signalmeow/provisioning.go
+++ b/pkg/signalmeow/provisioning.go
@@ -112,16 +112,6 @@ func PerformProvisioning(incomingCtx context.Context, deviceStore DeviceStore, d
 		pniIdentityKeyPair, _ := libsignalgo.NewIdentityKeyPair(pniPublicKey, pniPrivateKey)
 		profileKey := libsignalgo.ProfileKey(provisioningMessage.GetProfileKey())
 
-		// For debugging purposes
-		//privateKey, _ := libsignalgo.DeserializePrivateKey(provisioningMessage.GetAciIdentityKeyPrivate())
-		//publicKey, _ := privateKey.GetPublicKey()
-		//privateBytes, _ := privateKey.Serialize()
-		//publicBytes, _ := publicKey.Serialize()
-		//aciBytes, _ := aciIdentityKeyPair.Serialize()
-		//zlog.Debug().Msgf("privateKeyBytes: %v", privateBytes)
-		//zlog.Debug().Msgf("publicKeyBytes: %v", publicBytes)
-		//zlog.Debug().Msgf("aciIdentityKeyPairBytes: %v", aciBytes)
-
 		username := *provisioningMessage.Number
 		password, _ := generateRandomPassword(22)
 		code := provisioningMessage.ProvisioningCode

--- a/pkg/signalmeow/receiving.go
+++ b/pkg/signalmeow/receiving.go
@@ -560,7 +560,7 @@ func (d *Device) incomingAPIMessageHandler(ctx context.Context, req *signalpb.We
 				zlog.Debug().Msgf("Recieved sync message contacts")
 				blob := content.SyncMessage.Contacts.Blob
 				if blob != nil {
-					contactsBytes, err := DownloadAttachment(blob)
+					contactsBytes, err := DownloadAttachment(ctx, blob)
 					if err != nil {
 						zlog.Err(err).Msg("Contacts Sync DownloadAttachment error")
 					}

--- a/provisioning.go
+++ b/provisioning.go
@@ -125,13 +125,13 @@ type Response struct {
 	Number string `json:"number,omitempty"`
 
 	// For response in ResolveIdentifier
-	ResolveIdentifierResponse
+	*ResolveIdentifierResponse
 }
 
 // ** Start New Chat ** //
 
 type ResolveIdentifierResponse struct {
-	RoomID      string                             `json:"room_id"`
+	RoomID      id.RoomID                          `json:"room_id"`
 	ChatID      ResolveIdentifierResponseChatID    `json:"chat_id"`
 	JustCreated bool                               `json:"just_created"`
 	OtherUser   ResolveIdentifierResponseOtherUser `json:"other_user"`
@@ -170,7 +170,7 @@ func (prov *ProvisioningAPI) resolveIdentifier(user *User, phoneNum string) (int
 	puppet := prov.bridge.GetPuppetBySignalID(contact.UUID)
 
 	return http.StatusOK, &ResolveIdentifierResponse{
-		RoomID: portal.MXID.String(),
+		RoomID: portal.MXID,
 		ChatID: ResolveIdentifierResponseChatID{
 			UUID:   contact.UUID.String(),
 			Number: phoneNum,
@@ -207,7 +207,7 @@ func (prov *ProvisioningAPI) ResolveIdentifier(w http.ResponseWriter, r *http.Re
 	jsonResponse(w, status, Response{
 		Success:                   true,
 		Status:                    "ok",
-		ResolveIdentifierResponse: *resp,
+		ResolveIdentifierResponse: resp,
 	})
 }
 
@@ -245,7 +245,7 @@ func (prov *ProvisioningAPI) StartPM(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		resp.JustCreated = true
-		resp.RoomID = portal.MXID.String()
+		resp.RoomID = portal.MXID
 	}
 	if resp.JustCreated {
 		status = http.StatusCreated
@@ -254,7 +254,7 @@ func (prov *ProvisioningAPI) StartPM(w http.ResponseWriter, r *http.Request) {
 	jsonResponse(w, status, Response{
 		Success:                   true,
 		Status:                    "ok",
-		ResolveIdentifierResponse: *resp,
+		ResolveIdentifierResponse: resp,
 	})
 }
 

--- a/provisioning.go
+++ b/provisioning.go
@@ -17,12 +17,10 @@
 package main
 
 import (
-	"bufio"
 	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
-	"net"
 	"net/http"
 	_ "net/http/pprof"
 	"strconv"
@@ -35,9 +33,16 @@ import (
 	"github.com/gorilla/mux"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/hlog"
+	"maunium.net/go/mautrix"
 	"maunium.net/go/mautrix/id"
 
 	"go.mau.fi/mautrix-signal/pkg/signalmeow"
+)
+
+type provisioningContextKey int
+
+const (
+	provisioningUserKey provisioningContextKey = iota
 )
 
 type provisioningHandle struct {
@@ -78,50 +83,26 @@ func (prov *ProvisioningAPI) Init() {
 	}
 }
 
-type responseWrap struct {
-	http.ResponseWriter
-	statusCode int
-}
-
-func jsonResponse(w http.ResponseWriter, status int, response interface{}) {
+func jsonResponse(w http.ResponseWriter, status int, response any) {
 	w.Header().Add("Content-Type", "application/json")
 	w.WriteHeader(status)
 	_ = json.NewEncoder(w).Encode(response)
 }
 
-var _ http.Hijacker = (*responseWrap)(nil)
-
-func (rw *responseWrap) WriteHeader(statusCode int) {
-	rw.ResponseWriter.WriteHeader(statusCode)
-	rw.statusCode = statusCode
-}
-
-func (rw *responseWrap) Hijack() (net.Conn, *bufio.ReadWriter, error) {
-	hijacker, ok := rw.ResponseWriter.(http.Hijacker)
-	if !ok {
-		return nil, nil, errors.New("response does not implement http.Hijacker")
-	}
-	return hijacker.Hijack()
-}
-
 func (prov *ProvisioningAPI) AuthMiddleware(h http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		auth := r.Header.Get("Authorization")
-		if strings.HasPrefix(auth, "Bearer ") {
-			auth = auth[len("Bearer "):]
-		}
+		auth := strings.TrimPrefix(r.Header.Get("Authorization"), "Bearer ")
 		if auth != prov.bridge.Config.Bridge.Provisioning.SharedSecret {
-			prov.log.Info().Msg("Authentication token does not match shared secret")
-			jsonResponse(w, http.StatusForbidden, map[string]interface{}{
-				"error":   "Authentication token does not match shared secret",
-				"errcode": "M_FORBIDDEN",
+			zerolog.Ctx(r.Context()).Warn().Msg("Authentication token does not match shared secret")
+			jsonResponse(w, http.StatusForbidden, &mautrix.RespError{
+				Err:     "Authentication token does not match shared secret",
+				ErrCode: mautrix.MForbidden.ErrCode,
 			})
 			return
 		}
 		userID := r.URL.Query().Get("user_id")
 		user := prov.bridge.GetUserByMXID(id.UserID(userID))
-		wWrap := &responseWrap{w, 200}
-		h.ServeHTTP(wWrap, r.WithContext(context.WithValue(r.Context(), "user", user)))
+		h.ServeHTTP(w, r.WithContext(context.WithValue(r.Context(), provisioningUserKey, user)))
 	})
 }
 
@@ -203,7 +184,7 @@ func (prov *ProvisioningAPI) resolveIdentifier(user *User, phoneNum string) (int
 }
 
 func (prov *ProvisioningAPI) ResolveIdentifier(w http.ResponseWriter, r *http.Request) {
-	user := r.Context().Value("user").(*User)
+	user := r.Context().Value(provisioningUserKey).(*User)
 	phoneNum, _ := mux.Vars(r)["phonenum"]
 	prov.log.Debug().Msgf("ResolveIdentifier from %v, phone number: %v", user.MXID, phoneNum)
 
@@ -231,7 +212,7 @@ func (prov *ProvisioningAPI) ResolveIdentifier(w http.ResponseWriter, r *http.Re
 }
 
 func (prov *ProvisioningAPI) StartPM(w http.ResponseWriter, r *http.Request) {
-	user := r.Context().Value("user").(*User)
+	user := r.Context().Value(provisioningUserKey).(*User)
 	phoneNum, _ := mux.Vars(r)["phonenum"]
 	prov.log.Debug().Msgf("StartPM from %v, phone number: %v", user.MXID, phoneNum)
 
@@ -373,7 +354,7 @@ func (prov *ProvisioningAPI) loginOrSendError(w http.ResponseWriter, user *User)
 }
 
 func (prov *ProvisioningAPI) checkSessionAndReturnHandle(w http.ResponseWriter, r *http.Request, currentSession int) *provisioningHandle {
-	user := r.Context().Value("user").(*User)
+	user := r.Context().Value(provisioningUserKey).(*User)
 	handle := prov.existingSession(user)
 	if handle == nil {
 		prov.log.Warn().Msgf("checkSessionAndReturnHandle: from %v, no session found", user.MXID)
@@ -399,7 +380,7 @@ func (prov *ProvisioningAPI) checkSessionAndReturnHandle(w http.ResponseWriter, 
 // ** Provisioning API ** //
 
 func (prov *ProvisioningAPI) LinkNew(w http.ResponseWriter, r *http.Request) {
-	user := r.Context().Value("user").(*User)
+	user := r.Context().Value(provisioningUserKey).(*User)
 
 	prov.log.Debug().Msgf("LinkNew from %v, starting login", user.MXID)
 	handle := prov.loginOrSendError(w, user)
@@ -447,7 +428,7 @@ func (prov *ProvisioningAPI) LinkNew(w http.ResponseWriter, r *http.Request) {
 }
 
 func (prov *ProvisioningAPI) LinkWaitForScan(w http.ResponseWriter, r *http.Request) {
-	user := r.Context().Value("user").(*User)
+	user := r.Context().Value(provisioningUserKey).(*User)
 	body := struct {
 		SessionID string `json:"session_id"`
 	}{}
@@ -535,7 +516,7 @@ func (prov *ProvisioningAPI) LinkWaitForScan(w http.ResponseWriter, r *http.Requ
 }
 
 func (prov *ProvisioningAPI) LinkWaitForAccount(w http.ResponseWriter, r *http.Request) {
-	user := r.Context().Value("user").(*User)
+	user := r.Context().Value(provisioningUserKey).(*User)
 	body := struct {
 		SessionID  string `json:"session_id"`
 		DeviceName string `json:"device_name"`
@@ -611,7 +592,7 @@ func (prov *ProvisioningAPI) LinkWaitForAccount(w http.ResponseWriter, r *http.R
 }
 
 func (prov *ProvisioningAPI) Logout(w http.ResponseWriter, r *http.Request) {
-	user := r.Context().Value("user").(*User)
+	user := r.Context().Value(provisioningUserKey).(*User)
 	prov.log.Debug().Msgf("Logout called from %v (but not logging out)", user.MXID)
 	prov.clearSession(user)
 

--- a/user.go
+++ b/user.go
@@ -684,7 +684,7 @@ func ensureGroupPuppetsAreJoinedToPortal(ctx context.Context, user *User, portal
 		return err
 	}
 	for _, member := range group.Members {
-		parsedUserID, err := uuid.Parse(member.UserId)
+		parsedUserID, err := uuid.Parse(member.UserID)
 		if err != nil {
 			// TODO log?
 			continue
@@ -694,7 +694,7 @@ func ensureGroupPuppetsAreJoinedToPortal(ctx context.Context, user *User, portal
 		}
 		memberPuppet := portal.bridge.GetPuppetBySignalID(parsedUserID)
 		if memberPuppet == nil {
-			user.log.Err(err).Msgf("no puppet found for signalID %s", member.UserId)
+			user.log.Err(err).Msgf("no puppet found for signalID %s", member.UserID)
 			continue
 		}
 		_ = updatePuppetWithSignalContact(context.TODO(), user, memberPuppet, nil)

--- a/user.go
+++ b/user.go
@@ -385,7 +385,7 @@ func (user *User) startupTryConnect(retryCount int) {
 	user.populateSignalDevice()
 
 	user.log.Debug().Msg("Connecting to Signal")
-	ctx := context.Background()
+	ctx := user.log.WithContext(context.Background())
 	statusChan, err := signalmeow.StartReceiveLoops(ctx, user.SignalDevice)
 
 	if err != nil {

--- a/user.go
+++ b/user.go
@@ -568,7 +568,7 @@ func (user *User) populateSignalDevice() *signalmeow.Device {
 	user.Lock()
 	defer user.Unlock()
 	log := user.log.With().
-		Str("action", "populate_signal_device").
+		Str("action", "populate signal device").
 		Str("signal_id", user.SignalID.String()).
 		Logger()
 
@@ -593,7 +593,7 @@ func (user *User) populateSignalDevice() *signalmeow.Device {
 
 func updatePuppetWithSignalContact(ctx context.Context, user *User, puppet *Puppet, newContactAvatar *types.ContactAvatar) error {
 	log := user.log.With().
-		Str("action", "update_puppet_with_signal_contact").
+		Str("action", "update puppet with signal contact").
 		Str("signal_id", puppet.SignalID.String()).
 		Logger()
 	contact, newProfileAvatar, err := user.SignalDevice.ContactByIDWithProfileAvatar(puppet.SignalID)


### PR DESCRIPTION
- provisioning: use libserv instead of custom logger
- provisioning: use proper context key
- provisioning: don't send resolve identifier response fields if nil
- signalmeow: use structured logging
- provisioning: use structured logging
- zerolog: remove instances of using global log
- user: use structured logging
- main: use structured logging
