### PR TITLE
Deduplicate users' UUIDs during schema upgrade

### DIFF
--- a/database/upgrades/16-refactor-postgres.sql
+++ b/database/upgrades/16-refactor-postgres.sql
@@ -101,6 +101,9 @@ ALTER TABLE puppet ALTER COLUMN avatar_url SET NOT NULL;
 ALTER TABLE puppet ALTER COLUMN access_token SET NOT NULL;
 ALTER TABLE puppet ALTER COLUMN name_quality DROP DEFAULT;
 
+UPDATE "user"
+    SET uuid=NULL
+    WHERE uuid IN (SELECT DISTINCT uuid FROM "user" WHERE uuid IS NOT NULL GROUP BY uuid HAVING COUNT(*)>1);
 ALTER TABLE "user" ADD CONSTRAINT user_uuid_unique UNIQUE(uuid);
 ALTER TABLE "user" RENAME COLUMN username TO phone;
 


### PR DESCRIPTION
Otherwise, upgrading to v16 may hit conflicts if two users share the same Signal UUID, which was possible in prior DB versions.

---

This is useful only when upgrading a DB from the signald version of the bridge, where some Matrix users had logged into the same Signal account (and thus shared the same UUID in the "users" table).

Though this removes Signal UUID associations from Matrix users, migrating from the signald version requires re-logging in anyways.

The only time this would not be safe is when migrating a DB that had already been migrated from signald (i.e. a v13-v15 version) and users logged back in, with some sharing the same Signal UUID.