### PR TITLE
Ensure user is invited to portals on update

### DIFF
--- a/portal.go
+++ b/portal.go
@@ -1043,6 +1043,8 @@ func (portal *Portal) handleSignalNormalDataMessage(source *User, sender *Puppet
 			log.Error().Err(err).Msg("Failed to create portal room")
 			return
 		}
+	} else if !portal.ensureUserInvited(ctx, source) {
+		log.Warn().Stringer("user_id", source.MXID).Msg("Failed to ensure source user is joined to portal")
 	}
 
 	existingMessage, err := portal.bridge.DB.Message.GetBySignalID(ctx, sender.SignalID, msg.GetTimestamp(), 0, portal.Receiver)


### PR DESCRIPTION
because if a user ever leaves a portal, there is no obvious way for them to rejoin it.

This restores 468f655, which was lost during a refactor.