### PR TITLE
handle Group Change

### DIFF
--- a/config/bridge.go
+++ b/config/bridge.go
@@ -48,6 +48,7 @@ type BridgeConfig struct {
 	MessageErrorNotices     bool `yaml:"message_error_notices"`
 	SyncDirectChatList      bool `yaml:"sync_direct_chat_list"`
 	ResendBridgeInfo        bool `yaml:"resend_bridge_info"`
+	PublicPortals           bool `yaml:"public_portals"`
 	CaptionInMessage        bool `yaml:"caption_in_message"`
 	FederateRooms           bool `yaml:"federate_rooms"`
 

--- a/config/upgrade.go
+++ b/config/upgrade.go
@@ -93,6 +93,7 @@ func DoUpgrade(helper *up.Helper) {
 	helper.Copy(up.Bool, "bridge", "message_error_notices")
 	helper.Copy(up.Bool, "bridge", "sync_direct_chat_list")
 	helper.Copy(up.Bool, "bridge", "resend_bridge_info")
+	helper.Copy(up.Bool, "bridge", "public_portals")
 	helper.Copy(up.Bool, "bridge", "caption_in_message")
 	helper.Copy(up.Bool, "bridge", "federate_rooms")
 	helper.Copy(up.Map, "bridge", "double_puppet_server_map")

--- a/example-config.yaml
+++ b/example-config.yaml
@@ -131,6 +131,9 @@ bridge:
     # Set this to true to tell the bridge to re-send m.bridge events to all rooms on the next run.
     # This field will automatically be changed back to false after it, except if the config file is not writable.
     resend_bridge_info: false
+    # Whether or not to make portals of groups that don't need approval of an admin to join by invite
+    # link publicly joinable on Matrix.
+    public_portals: false
     # Send captions in the same message as images. This will send data compatible with both MSC2530.
     # This is currently not supported in most clients.
     caption_in_message: false

--- a/pkg/libsignalgo/verifysignature.go
+++ b/pkg/libsignalgo/verifysignature.go
@@ -1,0 +1,46 @@
+// mautrix-signal - A Matrix-signal puppeting bridge.
+// Copyright (C) 2023 Scott Weber
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package libsignalgo
+
+/*
+#cgo LDFLAGS: -lsignal_ffi -ldl -lm
+#include "./libsignal-ffi.h"
+#include <stdlib.h>
+*/
+import "C"
+import (
+	"runtime"
+	"unsafe"
+)
+
+type NotarySignature [C.SignalSIGNATURE_LEN]byte
+
+func ServerPublicParamsVerifySignature(
+	serverPublicParams ServerPublicParams,
+	messageBytes []byte,
+	NotarySignature NotarySignature,
+) error {
+	c_notarySignature := (*[C.SignalSIGNATURE_LEN]C.uint8_t)(unsafe.Pointer(&NotarySignature[0]))
+	c_serverPublicParams := (*[C.SignalSERVER_PUBLIC_PARAMS_LEN]C.uchar)(unsafe.Pointer(&serverPublicParams[0]))
+	signalFfiError := C.signal_server_public_params_verify_signature(
+		c_serverPublicParams,
+		BytesToBuffer(messageBytes),
+		c_notarySignature,
+	)
+	runtime.KeepAlive(messageBytes)
+	return wrapError(signalFfiError)
+}

--- a/pkg/signalmeow/groups.go
+++ b/pkg/signalmeow/groups.go
@@ -690,7 +690,6 @@ func DecryptGroupChange(ctx context.Context, groupContext *signalpb.GroupContext
 		decryptedGroupChange.DeleteMembers = append(decryptedGroupChange.DeleteMembers, &userID)
 	}
 
-	decryptedGroupChange.ModifyMemberRoles = make([]*RoleMember, 0)
 	for _, modifyMemberRole := range encryptedActions.ModifyMemberRoles {
 		encryptedUserID := libsignalgo.UUIDCiphertext(modifyMemberRole.UserId)
 		userID, err := groupSecretParams.DecryptUUID(encryptedUserID)

--- a/pkg/signalmeow/groups.go
+++ b/pkg/signalmeow/groups.go
@@ -629,9 +629,10 @@ func (cli *Client) DecryptGroupChange(ctx context.Context, groupContext *signalp
 		return nil, err
 	}
 
-	decryptedGroupChange := &GroupChange{groupMasterKey: groupMasterKey}
-
-	decryptedGroupChange.Revision = encryptedActions.Revision
+	decryptedGroupChange := &GroupChange{
+		groupMasterKey: groupMasterKey,
+		Revision:       encryptedActions.Revision,
+	}
 
 	if encryptedActions.ModifyTitle != nil {
 		titleBlob, err := decryptGroupPropertyIntoBlob(groupSecretParams, encryptedActions.ModifyTitle.Title)

--- a/pkg/signalmeow/groups.go
+++ b/pkg/signalmeow/groups.go
@@ -677,7 +677,6 @@ func DecryptGroupChange(ctx context.Context, groupContext *signalpb.GroupContext
 		})
 	}
 
-	decryptedGroupChange.DeleteMembers = make([]*uuid.UUID, 0)
 	for _, deleteMember := range encryptedActions.DeleteMembers {
 		if deleteMember == nil {
 			continue

--- a/pkg/signalmeow/groups.go
+++ b/pkg/signalmeow/groups.go
@@ -140,27 +140,27 @@ type BannedMember struct {
 type GroupChange struct {
 	groupMasterKey types.SerializedGroupMasterKey
 
-	Revision                        uint32
-	AddMembers                      []*AddMember
-	DeleteMembers                   []*uuid.UUID
-	ModifyMemberRoles               []*RoleMember
-	ModifyMemberProfileKeys         []*ProfileKeyMember
-	AddPendingMembers               []*PendingMember
-	DeletePendingMembers            []*uuid.UUID
-	PromotePendingMembers           []*ProfileKeyMember
-	ModifyTitle                     *string
-	ModifyAvatar                    *string
-	ModifyDisappearingMessagesTimer *uint32
-	ModifyAttributesAccess          *AccessControl
-	ModifyMemberAccess              *AccessControl
-	ModifyAddFromInviteLinkAccess   *AccessControl
-	AddRequestingMembers            []*RequestingMember
-	DeleteRequestingMembers         []*uuid.UUID
-	PromoteRequestingMembers        []*RoleMember
-	ModifyDescription               *string
-	ModifyAnnouncementsOnly         *bool
-	AddBannedMembers                []*BannedMember
-	DeleteBannedMembers             []*uuid.UUID
+	Revision                           uint32
+	AddMembers                         []*AddMember
+	DeleteMembers                      []*uuid.UUID
+	ModifyMemberRoles                  []*RoleMember
+	ModifyMemberProfileKeys            []*ProfileKeyMember
+	AddPendingMembers                  []*PendingMember
+	DeletePendingMembers               []*uuid.UUID
+	PromotePendingMembers              []*ProfileKeyMember
+	ModifyTitle                        *string
+	ModifyAvatar                       *string
+	ModifyDisappearingMessagesDuration *uint32
+	ModifyAttributesAccess             *AccessControl
+	ModifyMemberAccess                 *AccessControl
+	ModifyAddFromInviteLinkAccess      *AccessControl
+	AddRequestingMembers               []*RequestingMember
+	DeleteRequestingMembers            []*uuid.UUID
+	PromoteRequestingMembers           []*RoleMember
+	ModifyDescription                  *string
+	ModifyAnnouncementsOnly            *bool
+	AddBannedMembers                   []*BannedMember
+	DeleteBannedMembers                []*uuid.UUID
 	//PromotePendingPniAciMembers     []*PromotePniAciMember
 	//ModifyInviteLinkPassword        []byte
 }
@@ -921,6 +921,14 @@ func (cli *Client) DecryptGroupChange(ctx context.Context, groupContext *signalp
 
 	if encryptedActions.ModifyAnnouncementsOnly != nil {
 		decryptedGroupChange.ModifyAnnouncementsOnly = &encryptedActions.ModifyAnnouncementsOnly.AnnouncementsOnly
+	}
+	if encryptedActions.ModifyDisappearingMessagesTimer != nil && len(encryptedActions.ModifyDisappearingMessagesTimer.Timer) > 0 {
+		timerBlob, err := decryptGroupPropertyIntoBlob(groupSecretParams, encryptedActions.ModifyDisappearingMessagesTimer.Timer)
+		if err != nil {
+			return nil, err
+		}
+		newDisappaeringMessagesDuration := timerBlob.GetDisappearingMessagesDuration()
+		decryptedGroupChange.ModifyDisappearingMessagesDuration = &newDisappaeringMessagesDuration
 	}
 
 	return decryptedGroupChange, nil

--- a/pkg/signalmeow/groups.go
+++ b/pkg/signalmeow/groups.go
@@ -650,7 +650,6 @@ func DecryptGroupChange(ctx context.Context, groupContext *signalpb.GroupContext
 		}
 	}
 
-	decryptedGroupChange.AddMembers = make([]*AddMember, 0)
 	for _, addMember := range encryptedActions.AddMembers {
 		if addMember == nil {
 			continue

--- a/portal.go
+++ b/portal.go
@@ -1053,7 +1053,7 @@ func (portal *Portal) handleSignalGroupChange(source *User, sender *Puppet, grou
 				if modifyRole.Role == signalmeow.GroupMember_ADMINISTRATOR {
 					powerLevel = 50
 				}
-				levels.EnsureUserLevel(puppet.MXID, powerLevel)
+				levels.EnsureUserLevel(puppet.IntentFor(portal).UserID, powerLevel)
 				if puppet.customIntent == nil {
 					user := portal.bridge.GetUserBySignalID(modifyRole.UserID)
 					if user != nil {


### PR DESCRIPTION
There is more to come, but this part should already work.
What's missing is kicking Users. It currently only kicks the User's puppet.
Another problem is that mautrix-signal doesn't set room permissions and power levels correctly yet, so some actions have to be performed by the bridge bot. Make sure to give yourself appropriate permissions through `set-pl` before testing.

Also includes a fix where the avatar was not set if there wasn't one to begin with.