### PR TITLE
Avoid nil dereference on existing reaction lookup

### DIFF
--- a/portal.go
+++ b/portal.go
@@ -937,7 +937,7 @@ func (portal *Portal) handleSignalReaction(sender *Puppet, react *signalpb.DataM
 	if err != nil {
 		log.Err(err).Msg("Failed to get existing reaction from database")
 		return
-	} else if existingReaction.Emoji == react.GetEmoji() {
+	} else if existingReaction != nil && existingReaction.Emoji == react.GetEmoji() {
 		log.Debug().Msg("Ignoring duplicate reaction")
 		return
 	}


### PR DESCRIPTION
Otherwise, the bridge crashes when it sees a reaction from Signal.

---

This fixes a crash introduced by 666ccf1.