### PR TITLE
Add config to deny `login-matrix`

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -21,6 +21,8 @@ import (
 	"maunium.net/go/mautrix/id"
 )
 
+const PermissionLevelFull bridgeconfig.PermissionLevel = 15
+
 type Config struct {
 	*bridgeconfig.BaseConfig `yaml:",inline"`
 

--- a/config/upgrade.go
+++ b/config/upgrade.go
@@ -133,6 +133,7 @@ func DoUpgrade(helper *up.Helper) {
 	}
 	helper.Copy(up.Bool, "bridge", "provisioning", "debug_endpoints")
 
+	bridgeconfig.RegisterPermissionLevel("full", 15)
 	helper.Copy(up.Map, "bridge", "permissions")
 	helper.Copy(up.Bool, "bridge", "relay", "enabled")
 	helper.Copy(up.Bool, "bridge", "relay", "admin_only")

--- a/example-config.yaml
+++ b/example-config.yaml
@@ -263,9 +263,11 @@ bridge:
 
     # Permissions for using the bridge.
     # Permitted values:
+    #    block - No access (default)
     #    relay - Talk through the relaybot (if enabled), no access otherwise
-    #     user - Access to use the bridge to chat with a Signal account.
-    #    admin - User level and some additional administration tools
+    #     user - Access to use the bridge by logging in with a Signal account
+    #     full - User level + Matrix login
+    #    admin - Full level + additional administration tools
     # Permitted keys:
     #        * - All Matrix users
     #   domain - All users on that homeserver


### PR DESCRIPTION
This changes user bridge permissions to be more like mautrix-telegram's, which has a separate permission level for controlling access to double-puppeting.