### PR TITLE
Don't no-op logouts

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -137,7 +137,7 @@ func fnDeleteSession(ce *WrappedCommandEvent) {
 		ce.Reply("You're not logged in")
 		return
 	}
-	ce.User.Client.ClearKeysAndDisconnect(ce.Ctx)
+	ce.User.clearKeysAndDisconnect(ce.Ctx)
 	ce.Reply("Disconnected from Signal")
 }
 

--- a/commands.go
+++ b/commands.go
@@ -52,6 +52,7 @@ func (br *SignalBridge) RegisterCommands() {
 	proc.AddHandlers(
 		cmdPing,
 		cmdLogin,
+		cmdLogout,
 		cmdSetDeviceName,
 		cmdPM,
 		cmdResolvePhone,
@@ -435,6 +436,27 @@ func fnLogin(ce *WrappedCommandEvent) {
 	// Connect to Signal
 	ce.User.Connect()
 	ce.Reply("Successfully logged in as %s (UUID: %s)", ce.User.SignalUsername, ce.User.SignalID)
+}
+
+var cmdLogout = &commands.FullHandler{
+	Func: wrapCommand(fnLogout),
+	Name: "logout",
+	Help: commands.HelpMeta{
+		Section:     commands.HelpSectionAuth,
+		Description: "Unlink the bridge from your Signal account.",
+	},
+}
+
+func fnLogout(ce *WrappedCommandEvent) {
+	if !ce.User.IsLoggedIn() {
+		ce.Reply("You're not logged in.")
+		return
+	}
+	err := ce.User.Logout()
+	if err != nil {
+		ce.User.log.Warn().Err(err).Msg("Error while logging out")
+	}
+	ce.Reply("Logged out successfully.")
 }
 
 func (user *User) sendQR(ce *WrappedCommandEvent, code string, prevQR, prevMsg id.EventID) (qr, msg id.EventID) {

--- a/commands.go
+++ b/commands.go
@@ -443,7 +443,7 @@ var cmdLogout = &commands.FullHandler{
 	Name: "logout",
 	Help: commands.HelpMeta{
 		Section:     commands.HelpSectionAuth,
-		Description: "Unlink the bridge from your Signal account.",
+		Description: "Remove all local data about your Signal link",
 	},
 }
 
@@ -452,9 +452,11 @@ func fnLogout(ce *WrappedCommandEvent) {
 		ce.Reply("You're not logged in.")
 		return
 	}
-	err := ce.User.Logout()
+	err := ce.User.Logout(ce.Ctx)
 	if err != nil {
 		ce.User.log.Warn().Err(err).Msg("Error while logging out")
+		ce.Reply("Error while logging out: %v", err)
+		return
 	}
 	ce.Reply("Logged out successfully.")
 }

--- a/commands.go
+++ b/commands.go
@@ -151,10 +151,8 @@ var cmdPing = &commands.FullHandler{
 }
 
 func fnPing(ce *WrappedCommandEvent) {
-	if ce.User.SignalID == uuid.Nil {
+	if ce.User.SignalID == uuid.Nil || !ce.User.IsLoggedIn() {
 		ce.Reply("You're not logged in")
-	} else if !ce.User.IsLoggedIn() {
-		ce.Reply("You were logged in at some point, but are not anymore")
 	} else if !ce.User.Client.IsConnected() {
 		ce.Reply("You're logged into Signal, but not connected to the server")
 	} else {

--- a/main.go
+++ b/main.go
@@ -198,7 +198,13 @@ func (br *SignalBridge) Stop() {
 	br.Metrics.Stop()
 	for _, user := range br.usersByMXID {
 		br.ZLog.Debug().Stringer("user_id", user.MXID).Msg("Disconnecting user")
-		user.Disconnect()
+		err := user.Disconnect()
+		if err != nil {
+			br.ZLog.Debug().Err(err).
+				Str("action", "stop").
+				Stringer("user_id", user.MXID).
+				Msg("Error on disconnect")
+		}
 	}
 }
 

--- a/pkg/signalmeow/store/container.go
+++ b/pkg/signalmeow/store/container.go
@@ -18,6 +18,7 @@ var _ DeviceStore = (*StoreContainer)(nil)
 
 type DeviceStore interface {
 	PutDevice(ctx context.Context, dd *DeviceData) error
+	DeleteDevice(ctx context.Context, dd *DeviceData) error
 	DeviceByACI(ctx context.Context, aci uuid.UUID) (*Device, error)
 }
 

--- a/pkg/signalmeow/store/device.go
+++ b/pkg/signalmeow/store/device.go
@@ -92,3 +92,13 @@ func (d *Device) ClearPassword(ctx context.Context) error {
 	d.Password = ""
 	return d.DeviceStore.PutDevice(ctx, &d.DeviceData)
 }
+
+func (d *Device) DeleteDevice(ctx context.Context) error {
+	if err := d.DeviceStore.DeleteDevice(ctx, &d.DeviceData); err != nil {
+		return err
+	}
+	d.ACI = uuid.Nil
+	d.DeviceID = 0
+	d.Password = ""
+	return nil
+}

--- a/provisioning.go
+++ b/provisioning.go
@@ -682,10 +682,15 @@ func (prov *ProvisioningAPI) Logout(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	prov.clearSession(ctx, user)
-	err := user.Logout()
+	err := user.Logout(ctx)
 	if err != nil {
 		user.log.Warn().Err(err).Msg("Error while logging out")
+		jsonResponse(w, http.StatusInternalServerError, Error{
+			Success: false,
+			Error:   err.Error(),
+			ErrCode: "M_INTERNAL",
+		})
+		return
 	}
 
 	jsonResponse(w, http.StatusOK, Response{

--- a/user.go
+++ b/user.go
@@ -577,8 +577,10 @@ func (user *User) saveSignalID(ctx context.Context, id uuid.UUID, number string)
 				Stringer("signal_uuid", id).
 				Msg("Another user is already logged in with same UUID, logging out previous user")
 			existingUser.Lock()
-			existingUser.clearKeysAndDisconnect(ctx)
-			existingUser.Client = nil
+			if existingUser.Client != nil {
+				existingUser.clearKeysAndDisconnect(ctx)
+				existingUser.Client = nil
+			}
 			existingUser.handleLoggedOutNoLock(ctx)
 			existingUser.Unlock()
 			if managementRoom := existingUser.GetManagementRoomID(); managementRoom != "" {

--- a/user.go
+++ b/user.go
@@ -599,11 +599,9 @@ func (user *User) populateSignalDevice() *signalmeow.Client {
 
 	if user.SignalID == uuid.Nil {
 		return nil
-	}
-	// TODO clear client on logout properly so that populating can skip creating if it already exists
-	/*else if user.Client != nil {
+	} else if user.Client != nil {
 		return user.Client
-	}*/
+	}
 
 	device, err := user.bridge.MeowStore.DeviceByACI(context.TODO(), user.SignalID)
 	if err != nil {

--- a/user.go
+++ b/user.go
@@ -811,7 +811,9 @@ func (user *User) Logout() error {
 	user.log.Info().Msg("Logging out of session")
 	loggedOutDevice, err := user.disconnectNoLock()
 	user.bridge.MeowStore.DeleteDevice(context.TODO(), &loggedOutDevice.Store.DeviceData)
-	user.bridge.GetPuppetByCustomMXID(user.MXID).ClearCustomMXID()
+	if puppet := user.GetIDoublePuppet(); puppet != nil {
+		puppet.ClearCustomMXID()
+	}
 	return err
 }
 

--- a/user.go
+++ b/user.go
@@ -498,7 +498,9 @@ func (user *User) startupTryConnect(retryCount int) {
 				user.BridgeState.Send(status.BridgeState{StateEvent: status.StateUnknownError, Error: "unknown-websocket-error", Message: err.Error()})
 
 			case signalmeow.SignalConnectionCleanShutdown:
-				if user.Client.IsLoggedIn() {
+				if user.Client == nil {
+					user.log.Debug().Msg("Clean Shutdown, but no client - sending no BridgeState")
+				} else if user.Client.IsLoggedIn() {
 					user.log.Debug().Msg("Clean Shutdown - sending no BridgeState")
 				} else {
 					user.log.Debug().Msg("Clean Shutdown, but logged out - Sending BadCredentials BridgeState")

--- a/user.go
+++ b/user.go
@@ -861,7 +861,9 @@ func (user *User) handleLoggedOutNoLock(ctx context.Context) {
 	if puppet := user.GetIDoublePuppet(); puppet != nil {
 		puppet.ClearCustomMXID()
 	}
-	user.bridge.provisioning.clearSession(ctx, user)
+	if user.bridge.provisioning != nil {
+		user.bridge.provisioning.clearSession(ctx, user)
+	}
 }
 
 func (user *User) UpdateDirectChats(ctx context.Context, chats map[id.UserID][]id.RoomID) {

--- a/user.go
+++ b/user.go
@@ -569,7 +569,9 @@ func (user *User) saveSignalID(ctx context.Context, id uuid.UUID, number string)
 				Stringer("previous_user", existingUser.MXID).
 				Stringer("signal_uuid", id).
 				Msg("Another user is already logged in with same UUID, logging out previous user")
-			_ = existingUser.Disconnect()
+			if err := existingUser.Disconnect(); err != nil {
+				zerolog.Ctx(ctx).Debug().Err(err).Msg("Error on disconnect")
+			}
 			existingUser.SignalID = uuid.Nil
 			existingUser.SignalUsername = ""
 			err := existingUser.Update(ctx)

--- a/user.go
+++ b/user.go
@@ -817,6 +817,9 @@ func (user *User) Logout(ctx context.Context) error {
 	if _, err := user.disconnectNoLock(); err != nil {
 		user.log.Debug().Err(err).Msg("Error on disconnect")
 	}
+	user.SignalUsername = ""
+	user.SignalID = uuid.Nil
+	user.Update(ctx)
 	if puppet := user.GetIDoublePuppet(); puppet != nil {
 		puppet.ClearCustomMXID()
 	}

--- a/user.go
+++ b/user.go
@@ -579,6 +579,9 @@ func (user *User) saveSignalID(ctx context.Context, id uuid.UUID, number string)
 			existingUser.Client = nil
 			existingUser.handleLoggedOutNoLock(ctx)
 			existingUser.Unlock()
+			if managementRoom := existingUser.GetManagementRoomID(); managementRoom != "" {
+				_, _ = existingUser.bridge.Bot.SendText(ctx, managementRoom, "Another user of this bridge has logged into your Signal account")
+			}
 		}
 	}
 	user.SignalID = id


### PR DESCRIPTION
Disconnect bridge users from their accounts on logout. This does not
actually delete the Signal device being logged out of, though.