### PR TITLE
Always fetch profile on update info, and reduce profile data leaks

### DIFF
--- a/pkg/signalmeow/profile.go
+++ b/pkg/signalmeow/profile.go
@@ -162,6 +162,10 @@ func (cli *Client) RetrieveProfileByID(ctx context.Context, signalID uuid.UUID) 
 	return profile, nil
 }
 
+func (cli *Client) IsProfileHiddenFromOthers(ctx context.Context, profileUUID uuid.UUID) (bool, error) {
+	return cli.Store.ContactStore.IsProfileHiddenFromOthers(ctx, profileUUID)
+}
+
 func (cli *Client) fetchProfileByID(ctx context.Context, signalID uuid.UUID) (*Profile, error) {
 	log := zerolog.Ctx(ctx)
 	profileKey, err := cli.ProfileKeyForSignalID(ctx, signalID)

--- a/puppet.go
+++ b/puppet.go
@@ -255,6 +255,19 @@ func (puppet *Puppet) UpdateInfo(ctx context.Context, source *User, info *types.
 			info = infoWithProfile
 		}
 	}
+	if info.ProfileKey != nil {
+		if profileIsHiddenFromOthers, err := source.Client.IsProfileHiddenFromOthers(ctx, info.UUID); err != nil {
+			log.Err(err).Msg("Failed to check if profile is hidden from other user(s)")
+			return
+		} else if profileIsHiddenFromOthers {
+			log.Debug().Msg("Profile is hidden from other user(s), so hide it globally to avoid leaking it")
+			info.ProfileName = ""
+			info.ProfileAbout = ""
+			info.ProfileAboutEmoji = ""
+			info.ProfileAvatarPath = ""
+			info.ProfileAvatarHash = ""
+		}
+	}
 
 	log.Trace().Msg("Updating puppet info")
 

--- a/puppet.go
+++ b/puppet.go
@@ -242,12 +242,17 @@ func (puppet *Puppet) UpdateInfo(ctx context.Context, source *User, info *types.
 		Logger()
 	ctx = log.WithContext(ctx)
 	var err error
-	if info == nil {
-		log.Debug().Msg("Fetching contact info to update puppet")
-		info, err = source.Client.ContactByID(ctx, puppet.SignalID)
+	{
+		var infoWithProfile *types.Contact
+		log.Debug().Msg("Fetching profile & contact info to update puppet")
+		infoWithProfile, err = source.Client.ContactByID(ctx, puppet.SignalID)
 		if err != nil {
-			log.Err(err).Msg("Failed to fetch contact info")
-			return
+			log.Err(err).Msg("Failed to fetch profile & contact info")
+			if info == nil {
+				return
+			}
+		} else if infoWithProfile != nil {
+			info = infoWithProfile
 		}
 	}
 


### PR DESCRIPTION
This helps with #396 insofar as it should prevent puppets' displaynames/avatars from being set/unset as often.  However, it still allows displaynames to be "downgraded" to avoid sharing profile info with users that it's not shared with in Signal.

It's worth mentioning that until Matrix supports locally-overrideable profile info like Signal does, any attempt to lock down bridged profile visibility to the same extent that Signal does will either be overly strict, or not strict enough.

See commit descriptions for details.