### PR TITLE
Use latest profile info

### DIFF
--- a/config/bridge.go
+++ b/config/bridge.go
@@ -169,12 +169,12 @@ type DisplaynameParams struct {
 func (bc BridgeConfig) FormatDisplayname(contact *types.Contact) string {
 	var buffer strings.Builder
 	_ = bc.displaynameTemplate.Execute(&buffer, DisplaynameParams{
-		ProfileName: contact.ProfileName,
+		ProfileName: contact.Profile.Name,
 		ContactName: contact.ContactName,
 		//Username:    contact.Username,
 		PhoneNumber: contact.E164,
 		UUID:        contact.UUID.String(),
-		AboutEmoji:  contact.ProfileAboutEmoji,
+		AboutEmoji:  contact.Profile.AboutEmoji,
 	})
 	return buffer.String()
 }

--- a/pkg/signalmeow/contact.go
+++ b/pkg/signalmeow/contact.go
@@ -116,7 +116,7 @@ func (cli *Client) fetchContactThenTryAndUpdateWithProfile(ctx context.Context, 
 	} else {
 		log.Debug().Msg("updating existing contact")
 	}
-	profile, err := cli.RetrieveProfileByID(ctx, profileUUID)
+	profile, lastFetched, err := cli.RetrieveProfileByID(ctx, profileUUID)
 	if err != nil {
 		log.Err(err).Msg("error retrieving profile")
 		//return nil, nil, err
@@ -147,6 +147,7 @@ func (cli *Client) fetchContactThenTryAndUpdateWithProfile(ctx context.Context, 
 	}
 
 	if contactChanged {
+		existingContact.ProfileFetchTs = lastFetched.UnixMilli()
 		err := cli.Store.ContactStore.StoreContact(ctx, *existingContact)
 		if err != nil {
 			log.Err(err).Msg("error storing contact")

--- a/pkg/signalmeow/contact.go
+++ b/pkg/signalmeow/contact.go
@@ -121,9 +121,7 @@ func (cli *Client) fetchContactThenTryAndUpdateWithProfile(ctx context.Context, 
 		log.Err(err).Msg("error retrieving profile")
 		//return nil, nil, err
 		// Don't return here, we still want to return what we have
-	}
-
-	if profile != nil {
+	} else if profile != nil {
 		if existingContact.ProfileName != profile.Name {
 			existingContact.ProfileName = profile.Name
 			contactChanged = true
@@ -152,6 +150,16 @@ func (cli *Client) fetchContactThenTryAndUpdateWithProfile(ctx context.Context, 
 		if err != nil {
 			log.Err(err).Msg("error storing contact")
 			return nil, err
+		}
+	}
+
+	if err != nil {
+		var otherContact *types.Contact
+		otherContact, err = cli.Store.ContactStore.LoadContactWithLatestOtherProfile(ctx, existingContact)
+		if err != nil {
+			log.Err(err).Msg("error retrieving contact with a newer profile from other users")
+		} else if otherContact != nil {
+			existingContact = otherContact
 		}
 	}
 	return existingContact, nil

--- a/pkg/signalmeow/contact.go
+++ b/pkg/signalmeow/contact.go
@@ -159,7 +159,10 @@ func (cli *Client) fetchContactThenTryAndUpdateWithProfile(ctx context.Context, 
 		if err != nil {
 			log.Err(err).Msg("error retrieving contact with a newer profile from other users")
 		} else if otherContact != nil {
-			existingContact = otherContact
+			existingContact.ProfileName = otherContact.ProfileName
+			existingContact.ProfileAbout = otherContact.ProfileAbout
+			existingContact.ProfileAboutEmoji = otherContact.ProfileAboutEmoji
+			existingContact.ProfileAvatarPath = otherContact.ProfileAvatarPath
 		}
 	}
 	return existingContact, nil

--- a/pkg/signalmeow/contact.go
+++ b/pkg/signalmeow/contact.go
@@ -62,7 +62,7 @@ func (cli *Client) StoreContactDetailsAsContact(ctx context.Context, contactDeta
 	existingContact.ContactName = contactDetails.GetName()
 	if profileKeyString := contactDetails.GetProfileKey(); profileKeyString != nil {
 		profileKey := libsignalgo.ProfileKey(profileKeyString)
-		existingContact.ProfileKey = &profileKey
+		existingContact.Profile.Key = &profileKey
 		err = cli.Store.ProfileKeyStore.StoreProfileKey(ctx, existingContact.UUID, profileKey)
 		if err != nil {
 			log.Err(err).Msg("storing profile key")
@@ -122,24 +122,24 @@ func (cli *Client) fetchContactThenTryAndUpdateWithProfile(ctx context.Context, 
 		//return nil, nil, err
 		// Don't return here, we still want to return what we have
 	} else if profile != nil {
-		if existingContact.ProfileName != profile.Name {
-			existingContact.ProfileName = profile.Name
+		if existingContact.Profile.Name != profile.Name {
+			existingContact.Profile.Name = profile.Name
 			contactChanged = true
 		}
-		if existingContact.ProfileAbout != profile.About {
-			existingContact.ProfileAbout = profile.About
+		if existingContact.Profile.About != profile.About {
+			existingContact.Profile.About = profile.About
 			contactChanged = true
 		}
-		if existingContact.ProfileAboutEmoji != profile.AboutEmoji {
-			existingContact.ProfileAboutEmoji = profile.AboutEmoji
+		if existingContact.Profile.AboutEmoji != profile.AboutEmoji {
+			existingContact.Profile.AboutEmoji = profile.AboutEmoji
 			contactChanged = true
 		}
-		if existingContact.ProfileAvatarPath != profile.AvatarPath {
-			existingContact.ProfileAvatarPath = profile.AvatarPath
+		if existingContact.Profile.AvatarPath != profile.AvatarPath {
+			existingContact.Profile.AvatarPath = profile.AvatarPath
 			contactChanged = true
 		}
-		if existingContact.ProfileKey == nil || *existingContact.ProfileKey != profile.Key {
-			existingContact.ProfileKey = &profile.Key
+		if existingContact.Profile.Key == nil || *existingContact.Profile.Key != profile.Key {
+			existingContact.Profile.Key = &profile.Key
 			contactChanged = true
 		}
 	}
@@ -159,10 +159,10 @@ func (cli *Client) fetchContactThenTryAndUpdateWithProfile(ctx context.Context, 
 		if err != nil {
 			log.Err(err).Msg("error retrieving contact with a newer profile from other users")
 		} else if otherContact != nil {
-			existingContact.ProfileName = otherContact.ProfileName
-			existingContact.ProfileAbout = otherContact.ProfileAbout
-			existingContact.ProfileAboutEmoji = otherContact.ProfileAboutEmoji
-			existingContact.ProfileAvatarPath = otherContact.ProfileAvatarPath
+			existingContact.Profile.Name = otherContact.Profile.Name
+			existingContact.Profile.About = otherContact.Profile.About
+			existingContact.Profile.AboutEmoji = otherContact.Profile.AboutEmoji
+			existingContact.Profile.AvatarPath = otherContact.Profile.AvatarPath
 		}
 	}
 	return existingContact, nil

--- a/pkg/signalmeow/contact.go
+++ b/pkg/signalmeow/contact.go
@@ -95,17 +95,17 @@ func (cli *Client) StoreContactDetailsAsContact(ctx context.Context, contactDeta
 	return existingContact, nil
 }
 
-func (cli *Client) fetchContactThenTryAndUpdateWithProfile(ctx context.Context, profileUUID uuid.UUID) (*types.Contact, error) {
+func (cli *Client) fetchContactThenTryAndUpdateWithProfile(ctx context.Context, profileUUID uuid.UUID) (existingContact *types.Contact, otherSourceUUID uuid.UUID, err error) {
 	log := zerolog.Ctx(ctx).With().
 		Str("action", "fetch contact then try and update with profile").
 		Stringer("profile_uuid", profileUUID).
 		Logger()
 	contactChanged := false
 
-	existingContact, err := cli.Store.ContactStore.LoadContact(ctx, profileUUID)
+	existingContact, err = cli.Store.ContactStore.LoadContact(ctx, profileUUID)
 	if err != nil {
 		log.Err(err).Msg("error loading contact")
-		return nil, err
+		return
 	}
 	if existingContact == nil {
 		log.Debug().Msg("creating new contact")
@@ -116,10 +116,9 @@ func (cli *Client) fetchContactThenTryAndUpdateWithProfile(ctx context.Context, 
 	} else {
 		log.Debug().Msg("updating existing contact")
 	}
-	profile, lastFetched, err := cli.RetrieveProfileByID(ctx, profileUUID)
-	if err != nil {
-		log.Err(err).Msg("error retrieving profile")
-		//return nil, nil, err
+	profile, lastFetched, fetchErr := cli.RetrieveProfileByID(ctx, profileUUID)
+	if fetchErr != nil {
+		log.Err(fetchErr).Msg("error retrieving profile")
 		// Don't return here, we still want to return what we have
 	} else if profile != nil {
 		if existingContact.Profile.Name != profile.Name {
@@ -146,26 +145,20 @@ func (cli *Client) fetchContactThenTryAndUpdateWithProfile(ctx context.Context, 
 
 	if contactChanged {
 		existingContact.ProfileFetchTs = lastFetched.UnixMilli()
-		err := cli.Store.ContactStore.StoreContact(ctx, *existingContact)
+		err = cli.Store.ContactStore.StoreContact(ctx, *existingContact)
 		if err != nil {
 			log.Err(err).Msg("error storing contact")
-			return nil, err
+			return
 		}
 	}
 
-	if err != nil {
-		var otherContact *types.Contact
-		otherContact, err = cli.Store.ContactStore.LoadContactWithLatestOtherProfile(ctx, existingContact)
-		if err != nil {
-			log.Err(err).Msg("error retrieving contact with a newer profile from other users")
-		} else if otherContact != nil {
-			existingContact.Profile.Name = otherContact.Profile.Name
-			existingContact.Profile.About = otherContact.Profile.About
-			existingContact.Profile.AboutEmoji = otherContact.Profile.AboutEmoji
-			existingContact.Profile.AvatarPath = otherContact.Profile.AvatarPath
+	if fetchErr != nil {
+		otherSourceUUID, fetchErr = cli.Store.ContactStore.UpdateContactWithLatestProfile(ctx, existingContact)
+		if fetchErr != nil {
+			log.Err(fetchErr).Msg("error retrieving latest profile for contact from other users")
 		}
 	}
-	return existingContact, nil
+	return
 }
 
 func (cli *Client) UpdateContactE164(ctx context.Context, uuid uuid.UUID, e164 string) error {
@@ -195,7 +188,7 @@ func (cli *Client) UpdateContactE164(ctx context.Context, uuid uuid.UUID, e164 s
 	return cli.Store.ContactStore.StoreContact(ctx, *existingContact)
 }
 
-func (cli *Client) ContactByID(ctx context.Context, uuid uuid.UUID) (*types.Contact, error) {
+func (cli *Client) ContactByID(ctx context.Context, uuid uuid.UUID) (contact *types.Contact, otherSourceUUID uuid.UUID, err error) {
 	return cli.fetchContactThenTryAndUpdateWithProfile(ctx, uuid)
 }
 
@@ -208,7 +201,7 @@ func (cli *Client) ContactByE164(ctx context.Context, e164 string) (*types.Conta
 	if contact == nil {
 		return nil, nil
 	}
-	contact, err = cli.fetchContactThenTryAndUpdateWithProfile(ctx, contact.UUID)
+	contact, _, err = cli.fetchContactThenTryAndUpdateWithProfile(ctx, contact.UUID)
 	return contact, err
 }
 

--- a/pkg/signalmeow/profile.go
+++ b/pkg/signalmeow/profile.go
@@ -247,6 +247,9 @@ func (cli *Client) fetchProfileByID(ctx context.Context, signalID uuid.UUID) (*P
 }
 
 func (cli *Client) DownloadUserAvatar(ctx context.Context, avatarPath string, profileKey *libsignalgo.ProfileKey) ([]byte, error) {
+	if profileKey == nil {
+		return nil, fmt.Errorf("failed to prepare request: profileKey is nil")
+	}
 	username, password := cli.Store.BasicAuthCreds()
 	opts := &web.HTTPReqOpt{
 		Host:     web.CDN1Hostname,

--- a/pkg/signalmeow/profile.go
+++ b/pkg/signalmeow/profile.go
@@ -35,6 +35,7 @@ import (
 	"github.com/rs/zerolog"
 
 	"go.mau.fi/mautrix-signal/pkg/libsignalgo"
+	"go.mau.fi/mautrix-signal/pkg/signalmeow/types"
 	"go.mau.fi/mautrix-signal/pkg/signalmeow/web"
 )
 
@@ -71,11 +72,8 @@ type ProfileResponse struct {
 }
 
 type Profile struct {
-	Name       string
-	About      string
-	AboutEmoji string
-	AvatarPath string
-	Key        libsignalgo.ProfileKey
+	types.ProfileFields
+	Key libsignalgo.ProfileKey
 }
 
 type ProfileCache struct {

--- a/pkg/signalmeow/store/contact_store.go
+++ b/pkg/signalmeow/store/contact_store.go
@@ -61,7 +61,7 @@ const (
 
 	getContactWithLatestOtherProfileQuery = getAllContactsQuery + `
 		WHERE our_aci_uuid <> $1 AND aci_uuid = $2 AND LENGTH(COALESCE(profile_key, '')) > 0
-		ORDER BY profile_fetch_ts LIMIT 1
+		ORDER BY profile_fetch_ts DESC LIMIT 1
 	`
 
 	upsertContactQuery = `

--- a/pkg/signalmeow/store/contact_store.go
+++ b/pkg/signalmeow/store/contact_store.go
@@ -122,10 +122,10 @@ func scanContact(row dbutil.Scannable) (*types.Contact, error) {
 		&contact.ContactName,
 		&contact.ContactAvatar.Hash,
 		&profileKey,
-		&contact.ProfileName,
-		&contact.ProfileAbout,
-		&contact.ProfileAboutEmoji,
-		&contact.ProfileAvatarPath,
+		&contact.Profile.Name,
+		&contact.Profile.About,
+		&contact.Profile.AboutEmoji,
+		&contact.Profile.AvatarPath,
 		&contact.ProfileAvatarHash,
 		&contact.ProfileFetchTs,
 	)
@@ -136,7 +136,7 @@ func scanContact(row dbutil.Scannable) (*types.Contact, error) {
 	}
 	if len(profileKey) != 0 {
 		profileKeyConverted := libsignalgo.ProfileKey(profileKey)
-		contact.ProfileKey = &profileKeyConverted
+		contact.Profile.Key = &profileKeyConverted
 	}
 	return &contact, err
 }
@@ -170,11 +170,11 @@ func (s *SQLStore) StoreContact(ctx context.Context, contact types.Contact) erro
 		contact.E164,
 		contact.ContactName,
 		contact.ContactAvatar.Hash,
-		contact.ProfileKey.Slice(),
-		contact.ProfileName,
-		contact.ProfileAbout,
-		contact.ProfileAboutEmoji,
-		contact.ProfileAvatarPath,
+		contact.Profile.Key.Slice(),
+		contact.Profile.Name,
+		contact.Profile.About,
+		contact.Profile.AboutEmoji,
+		contact.Profile.AvatarPath,
 		contact.ProfileAvatarHash,
 		contact.ProfileFetchTs,
 	)

--- a/pkg/signalmeow/store/contact_store.go
+++ b/pkg/signalmeow/store/contact_store.go
@@ -50,7 +50,8 @@ const (
 			profile_about,
 			profile_about_emoji,
 			profile_avatar_path,
-			profile_avatar_hash
+			profile_avatar_hash,
+			profile_fetch_ts
 		FROM signalmeow_contacts
 	`
 	getAllContactsOfUserQuery = getAllContactsQuery + `WHERE our_aci_uuid = $1`
@@ -68,9 +69,10 @@ const (
 			profile_about,
 			profile_about_emoji,
 			profile_avatar_path,
-			profile_avatar_hash
+			profile_avatar_hash,
+			profile_fetch_ts
 		)
-		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
 		ON CONFLICT (our_aci_uuid, aci_uuid) DO UPDATE SET
 			e164_number = excluded.e164_number,
 			contact_name = excluded.contact_name,
@@ -80,7 +82,8 @@ const (
 			profile_about = excluded.profile_about,
 			profile_about_emoji = excluded.profile_about_emoji,
 			profile_avatar_path = excluded.profile_avatar_path,
-			profile_avatar_hash = excluded.profile_avatar_hash
+			profile_avatar_hash = excluded.profile_avatar_hash,
+			profile_fetch_ts = excluded.profile_fetch_ts
 	`
 	upsertContactPhoneQuery = `
 		INSERT INTO signalmeow_contacts (
@@ -94,9 +97,10 @@ const (
 			profile_about,
 			profile_about_emoji,
 			profile_avatar_path,
-			profile_avatar_hash
+			profile_avatar_hash,
+			profile_fetch_ts
 		)
-		VALUES ($1, $2, $3, '', '', NULL, '', '', '', '', '')
+		VALUES ($1, $2, $3, '', '', NULL, '', '', '', '', '', 0)
 		ON CONFLICT (our_aci_uuid, aci_uuid) DO UPDATE
 			SET e164_number = excluded.e164_number
 	`
@@ -116,6 +120,7 @@ func scanContact(row dbutil.Scannable) (*types.Contact, error) {
 		&contact.ProfileAboutEmoji,
 		&contact.ProfileAvatarPath,
 		&contact.ProfileAvatarHash,
+		&contact.ProfileFetchTs,
 	)
 	if errors.Is(err, sql.ErrNoRows) {
 		return nil, nil
@@ -160,6 +165,7 @@ func (s *SQLStore) StoreContact(ctx context.Context, contact types.Contact) erro
 		contact.ProfileAboutEmoji,
 		contact.ProfileAvatarPath,
 		contact.ProfileAvatarHash,
+		contact.ProfileFetchTs,
 	)
 	return err
 }

--- a/pkg/signalmeow/store/upgrades/00-latest.sql
+++ b/pkg/signalmeow/store/upgrades/00-latest.sql
@@ -1,4 +1,4 @@
--- v0 -> v6: Latest revision
+-- v0 -> v7: Latest revision
 CREATE TABLE signalmeow_device (
     aci_uuid              TEXT PRIMARY KEY,
 
@@ -88,6 +88,7 @@ CREATE TABLE signalmeow_contacts (
     profile_about_emoji TEXT,
     profile_avatar_path TEXT NOT NULL DEFAULT '',
     profile_avatar_hash TEXT,
+    profile_fetch_ts    BIGINT NOT NULL DEFAULT 0,
 
     PRIMARY KEY (our_aci_uuid, aci_uuid),
     FOREIGN KEY (our_aci_uuid) REFERENCES signalmeow_device (aci_uuid) ON DELETE CASCADE ON UPDATE CASCADE

--- a/pkg/signalmeow/store/upgrades/07-profile-fetch-timestamps.sql
+++ b/pkg/signalmeow/store/upgrades/07-profile-fetch-timestamps.sql
@@ -1,0 +1,2 @@
+-- v7 (compatible with v5+): Save profile fetch timestamp
+ALTER TABLE signalmeow_contacts ADD COLUMN profile_fetch_ts BIGINT NOT NULL DEFAULT 0;

--- a/pkg/signalmeow/types/contact.go
+++ b/pkg/signalmeow/types/contact.go
@@ -38,6 +38,7 @@ type Contact struct {
 	ProfileAboutEmoji string
 	ProfileAvatarPath string
 	ProfileAvatarHash string
+	ProfileFetchTs    int64
 }
 
 type ContactAvatar struct {

--- a/pkg/signalmeow/types/contact.go
+++ b/pkg/signalmeow/types/contact.go
@@ -32,13 +32,14 @@ type Contact struct {
 	E164              string
 	ContactName       string
 	ContactAvatar     ContactAvatar
-	ProfileKey        *libsignalgo.ProfileKey
-	ProfileName       string
-	ProfileAbout      string
-	ProfileAboutEmoji string
-	ProfileAvatarPath string
+	Profile           ContactProfile
 	ProfileAvatarHash string
 	ProfileFetchTs    int64
+}
+
+type ContactProfile struct {
+	ProfileFields
+	Key *libsignalgo.ProfileKey
 }
 
 type ContactAvatar struct {

--- a/pkg/signalmeow/types/profile.go
+++ b/pkg/signalmeow/types/profile.go
@@ -1,0 +1,24 @@
+// mautrix-signal - A Matrix-signal puppeting bridge.
+// Copyright (C) 2023 Scott Weber, Tulir Asokan
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package types
+
+type ProfileFields struct {
+	Name       string
+	About      string
+	AboutEmoji string
+	AvatarPath string
+}

--- a/puppet.go
+++ b/puppet.go
@@ -317,10 +317,10 @@ func (puppet *Puppet) updateAvatar(ctx context.Context, source *User, info *type
 		puppet.AvatarSet = false
 		puppet.AvatarPath = ""
 	} else {
-		if puppet.AvatarPath == info.ProfileAvatarPath && puppet.AvatarSet {
+		if puppet.AvatarPath == info.Profile.AvatarPath && puppet.AvatarSet {
 			return false
 		}
-		if info.ProfileAvatarPath == "" {
+		if info.Profile.AvatarPath == "" {
 			puppet.AvatarURL = id.ContentURI{}
 			puppet.AvatarPath = ""
 			puppet.AvatarHash = ""
@@ -335,10 +335,10 @@ func (puppet *Puppet) updateAvatar(ctx context.Context, source *User, info *type
 			return true
 		}
 		var err error
-		avatarData, err = source.Client.DownloadUserAvatar(ctx, info.ProfileAvatarPath, info.ProfileKey)
+		avatarData, err = source.Client.DownloadUserAvatar(ctx, info.Profile.AvatarPath, info.Profile.Key)
 		if err != nil {
 			log.Err(err).
-				Str("profile_avatar_path", info.ProfileAvatarPath).
+				Str("profile_avatar_path", info.Profile.AvatarPath).
 				Msg("Failed to download new user avatar")
 			return true
 		}
@@ -354,7 +354,7 @@ func (puppet *Puppet) updateAvatar(ctx context.Context, source *User, info *type
 		// Path changed, but actual avatar didn't
 		return true
 	}
-	puppet.AvatarPath = info.ProfileAvatarPath
+	puppet.AvatarPath = info.Profile.AvatarPath
 	puppet.AvatarHash = newHash
 	puppet.AvatarSet = false
 	puppet.AvatarURL = id.ContentURI{}

--- a/puppet.go
+++ b/puppet.go
@@ -245,12 +245,21 @@ func (puppet *Puppet) UpdateInfo(ctx context.Context, source *User) {
 		log.Err(err).Msg("Failed to fetch contact info")
 		return
 	}
+	if sourceUUID != uuid.Nil {
+		source = puppet.bridge.GetUserBySignalID(sourceUUID)
+		if source == nil || source.Client == nil {
+			log.Warn().
+				Stringer("source_uuid", sourceUUID).
+				Msg("No fallback user for profile info update")
+			return
+		}
+		log.Debug().
+			Stringer("source_mxid", source.MXID).
+			Msg("Using fallback user for profile info update")
+	}
 
 	log.Trace().Msg("Updating puppet info")
 
-	if sourceUUID != uuid.Nil {
-		source = puppet.bridge.GetUserBySignalID(sourceUUID)
-	}
 	update := false
 	if info.E164 != "" && puppet.Number != info.E164 {
 		puppet.Number = info.E164

--- a/puppet.go
+++ b/puppet.go
@@ -240,7 +240,7 @@ func (puppet *Puppet) UpdateInfo(ctx context.Context, source *User) {
 	ctx = log.WithContext(ctx)
 	var err error
 	log.Debug().Msg("Fetching contact info to update puppet")
-	info, err := source.Client.ContactByID(ctx, puppet.SignalID)
+	info, sourceUUID, err := source.Client.ContactByID(ctx, puppet.SignalID)
 	if err != nil {
 		log.Err(err).Msg("Failed to fetch contact info")
 		return
@@ -248,6 +248,9 @@ func (puppet *Puppet) UpdateInfo(ctx context.Context, source *User) {
 
 	log.Trace().Msg("Updating puppet info")
 
+	if sourceUUID != uuid.Nil {
+		source = puppet.bridge.GetUserBySignalID(sourceUUID)
+	}
 	update := false
 	if info.E164 != "" && puppet.Number != info.E164 {
 		puppet.Number = info.E164


### PR DESCRIPTION
This is an alternative approach to #445 for helping with #396: if a Signal profile cannot be fetched by a particular bridged user's Signal account, use the profile info from the most recent successful fetch done by some other bridge user.

Profiles retrieved this way are used only as a fallback for setting a Signal puppet's displayname/avatar, not for updating the contact store.