### PR TITLE
Update profile avatar paths & hashes properly

### DIFF
--- a/puppet.go
+++ b/puppet.go
@@ -325,8 +325,8 @@ func (puppet *Puppet) updateAvatar(ctx context.Context, source *User, info *type
 			// TODO what to do? 🤔
 			return false
 		}
-		puppet.AvatarSet = false
 		puppet.AvatarPath = ""
+		puppet.AvatarHash = info.ContactAvatar.Hash
 	} else {
 		if puppet.AvatarPath == info.Profile.AvatarPath && puppet.AvatarSet {
 			return false
@@ -354,19 +354,24 @@ func (puppet *Puppet) updateAvatar(ctx context.Context, source *User, info *type
 			return true
 		}
 		avatarContentType = http.DetectContentType(avatarData)
+		puppet.AvatarPath = info.Profile.AvatarPath
+		hash := sha256.Sum256(avatarData)
+		newHash := hex.EncodeToString(hash[:])
+		if puppet.AvatarHash == newHash && puppet.AvatarSet {
+			log.Debug().
+				Str("avatar_hash", newHash).
+				Str("new_avatar_path", puppet.AvatarPath).
+				Msg("Avatar path changed, but hash didn't")
+			// Path changed, but actual avatar didn't
+			return true
+		}
+		puppet.AvatarHash = newHash
+		source.Client.Store.ContactStore.StoreContact(ctx, *info)
+		err = source.Client.Store.ContactStore.StoreContact(ctx, *info)
+		if err != nil {
+			log.Warn().Err(err).Msg("error updating contact's profile avatar hash")
+		}
 	}
-	hash := sha256.Sum256(avatarData)
-	newHash := hex.EncodeToString(hash[:])
-	if puppet.AvatarHash == newHash && puppet.AvatarSet {
-		log.Debug().
-			Str("avatar_hash", newHash).
-			Str("new_avatar_path", puppet.AvatarPath).
-			Msg("Avatar path changed, but hash didn't")
-		// Path changed, but actual avatar didn't
-		return true
-	}
-	puppet.AvatarPath = info.Profile.AvatarPath
-	puppet.AvatarHash = newHash
 	puppet.AvatarSet = false
 	puppet.AvatarURL = id.ContentURI{}
 	resp, err := puppet.DefaultIntent().UploadBytes(ctx, avatarData, avatarContentType)
@@ -383,7 +388,7 @@ func (puppet *Puppet) updateAvatar(ctx context.Context, source *User, info *type
 		return true
 	}
 	log.Debug().
-		Str("avatar_hash", newHash).
+		Str("avatar_hash", puppet.AvatarHash).
 		Stringer("avatar_mxc", resp.ContentURI).
 		Msg("Avatar updated successfully")
 	puppet.AvatarSet = true

--- a/puppet.go
+++ b/puppet.go
@@ -366,11 +366,6 @@ func (puppet *Puppet) updateAvatar(ctx context.Context, source *User, info *type
 			return true
 		}
 		puppet.AvatarHash = newHash
-		source.Client.Store.ContactStore.StoreContact(ctx, *info)
-		err = source.Client.Store.ContactStore.StoreContact(ctx, *info)
-		if err != nil {
-			log.Warn().Err(err).Msg("error updating contact's profile avatar hash")
-		}
 	}
 	puppet.AvatarSet = false
 	puppet.AvatarURL = id.ContentURI{}


### PR DESCRIPTION
This is a [leftover commit](https://github.com/mautrix/signal/pull/449/commits/38b8f3e63e9a30ced2f8323312d7e4817e133b1f) from https://github.com/mautrix/signal/pull/449 that may still be relevant.

When running the bridge without this change, avatar updates weren't getting saved to the store when I expected them to & new avatars wouldn't appear in Matrix until a bridge restart.