### PR TITLE
Make sqlite-compatible migration step

### DIFF
--- a/pkg/signalmeow/store/upgrades/08-resync-schema-449-postgres.sql
+++ b/pkg/signalmeow/store/upgrades/08-resync-schema-449-postgres.sql
@@ -1,4 +1,6 @@
--- v7 -> v8: Migration from https://github.com/mautrix/signal/pull/449 to match the new v8 upgrade
+-- v7 -> v8: Migration from https://github.com/mautrix/signal/pull/449 to match the new v8 upgrade (Postgres)
+-- only: postgres
+
 ALTER TABLE signalmeow_contacts DROP COLUMN profile_avatar_hash;
 ALTER TABLE signalmeow_contacts RENAME COLUMN profile_fetch_ts TO profile_fetched_at;
 ALTER TABLE signalmeow_contacts ALTER COLUMN profile_fetched_at DROP DEFAULT;

--- a/pkg/signalmeow/store/upgrades/09-resync-schema-449-sqlite.sql
+++ b/pkg/signalmeow/store/upgrades/09-resync-schema-449-sqlite.sql
@@ -1,0 +1,49 @@
+-- v9: Migration from https://github.com/mautrix/signal/pull/449 to match the new v8 upgrade (SQLite)
+-- transaction: off
+-- only: sqlite
+
+-- This is separate from v8 so that postgres can run with transaction: on
+-- (split upgrades by dialect don't currently allow disabling transaction in only one dialect)
+
+PRAGMA foreign_keys = OFF;
+BEGIN;
+
+ALTER TABLE signalmeow_contacts DROP COLUMN profile_avatar_hash;
+
+CREATE TABLE signalmeow_contacts_new (
+    our_aci_uuid        TEXT   NOT NULL,
+    aci_uuid            TEXT   NOT NULL,
+    e164_number         TEXT   NOT NULL,
+    contact_name        TEXT   NOT NULL,
+    contact_avatar_hash TEXT   NOT NULL,
+    profile_key         bytea,
+    profile_name        TEXT   NOT NULL,
+    profile_about       TEXT   NOT NULL,
+    profile_about_emoji TEXT   NOT NULL,
+    profile_avatar_path TEXT   NOT NULL,
+    profile_fetched_at  BIGINT,
+
+    PRIMARY KEY (our_aci_uuid, aci_uuid),
+    FOREIGN KEY (our_aci_uuid) REFERENCES signalmeow_device (aci_uuid) ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+INSERT INTO signalmeow_contacts_new
+SELECT our_aci_uuid,
+       aci_uuid,
+       e164_number,
+       contact_name,
+       contact_avatar_hash,
+       profile_key,
+       profile_name,
+       profile_about,
+       profile_about_emoji,
+       profile_avatar_path,
+       CASE WHEN profile_fetch_ts <= 0 THEN NULL ELSE profile_fetch_ts END
+FROM signalmeow_contacts;
+
+DROP TABLE signalmeow_contacts;
+ALTER TABLE signalmeow_contacts_new RENAME TO signalmeow_contacts;
+
+PRAGMA foreign_key_check;
+COMMIT;
+PRAGMA foreign_keys = ON;


### PR DESCRIPTION
The [schema upgrade](https://github.com/mautrix/signal/pull/464/files#diff-12b4f88ba8afff6707cb0c6ed319508ea582dcecd67857e6c6e1d7eff230f5a0) added in #464 uses `ALTER COLUMN`, so it's incompatible with SQLite.

This PR uses the same strategy as the [v16](https://github.com/mautrix/signal/blob/main/database/upgrades/16-refactor-postgres.sql) & [v17](https://github.com/mautrix/signal/blob/main/database/upgrades/17-refactor-sqlite.sql) upgrades for the main store to add a SQLite-compatible version of this migration.