### PR TITLE
Add handler for profile changes

### DIFF
--- a/pkg/signalmeow/contact.go
+++ b/pkg/signalmeow/contact.go
@@ -91,7 +91,7 @@ func (cli *Client) StoreContactDetailsAsContact(ctx context.Context, contactDeta
 	return existingContact, nil
 }
 
-func (cli *Client) fetchContactThenTryAndUpdateWithProfile(ctx context.Context, profileUUID uuid.UUID) (*types.Contact, error) {
+func (cli *Client) fetchContactThenTryAndUpdateWithProfile(ctx context.Context, profileUUID uuid.UUID, forceFetch bool) (*types.Contact, error) {
 	log := zerolog.Ctx(ctx).With().
 		Str("action", "fetch contact then try and update with profile").
 		Stringer("profile_uuid", profileUUID).
@@ -112,7 +112,7 @@ func (cli *Client) fetchContactThenTryAndUpdateWithProfile(ctx context.Context, 
 	} else {
 		log.Debug().Msg("updating existing contact")
 	}
-	profile, err := cli.RetrieveProfileByID(ctx, profileUUID)
+	profile, err := cli.RetrieveProfileByID(ctx, profileUUID, forceFetch)
 	if err != nil {
 		logLevel := zerolog.ErrorLevel
 		if errors.Is(err, errProfileKeyNotFound) {
@@ -164,8 +164,8 @@ func (cli *Client) UpdateContactE164(ctx context.Context, uuid uuid.UUID, e164 s
 	return cli.Store.ContactStore.StoreContact(ctx, *existingContact)
 }
 
-func (cli *Client) ContactByID(ctx context.Context, uuid uuid.UUID) (*types.Contact, error) {
-	return cli.fetchContactThenTryAndUpdateWithProfile(ctx, uuid)
+func (cli *Client) ContactByID(ctx context.Context, uuid uuid.UUID, forceFetch bool) (*types.Contact, error) {
+	return cli.fetchContactThenTryAndUpdateWithProfile(ctx, uuid, forceFetch)
 }
 
 func (cli *Client) ContactByE164(ctx context.Context, e164 string) (*types.Contact, error) {
@@ -177,7 +177,7 @@ func (cli *Client) ContactByE164(ctx context.Context, e164 string) (*types.Conta
 	if contact == nil {
 		return nil, nil
 	}
-	contact, err = cli.fetchContactThenTryAndUpdateWithProfile(ctx, contact.UUID)
+	contact, err = cli.fetchContactThenTryAndUpdateWithProfile(ctx, contact.UUID, false)
 	return contact, err
 }
 

--- a/pkg/signalmeow/events/message.go
+++ b/pkg/signalmeow/events/message.go
@@ -32,6 +32,7 @@ func (*Receipt) isSignalEvent()     {}
 func (*ReadSelf) isSignalEvent()    {}
 func (*Call) isSignalEvent()        {}
 func (*ContactList) isSignalEvent() {}
+func (*Profile) isSignalEvent()     {}
 
 type MessageInfo struct {
 	Sender uuid.UUID
@@ -62,4 +63,8 @@ type Call struct {
 
 type ContactList struct {
 	Contacts []*types.Contact
+}
+
+type Profile struct {
+	Sender uuid.UUID
 }

--- a/pkg/signalmeow/profile.go
+++ b/pkg/signalmeow/profile.go
@@ -111,7 +111,7 @@ func (cli *Client) ProfileKeyForSignalID(ctx context.Context, signalACI uuid.UUI
 
 var errProfileKeyNotFound = errors.New("profile key not found")
 
-func (cli *Client) RetrieveProfileByID(ctx context.Context, signalID uuid.UUID) (*types.Profile, error) {
+func (cli *Client) RetrieveProfileByID(ctx context.Context, signalID uuid.UUID, forceFetch bool) (*types.Profile, error) {
 	if cli.ProfileCache == nil {
 		cli.ProfileCache = &ProfileCache{
 			profiles:    make(map[string]*types.Profile),
@@ -120,17 +120,19 @@ func (cli *Client) RetrieveProfileByID(ctx context.Context, signalID uuid.UUID) 
 		}
 	}
 
-	// Check if we have a cached profile that is less than an hour old
-	// or if we have a cached error that is less than an hour old
-	lastFetched, ok := cli.ProfileCache.lastFetched[signalID.String()]
-	if ok && time.Since(lastFetched) < 1*time.Hour {
-		profile, ok := cli.ProfileCache.profiles[signalID.String()]
-		if ok {
-			return profile, nil
-		}
-		err, ok := cli.ProfileCache.errors[signalID.String()]
-		if ok {
-			return nil, *err
+	if !forceFetch {
+		// Check if we have a cached profile that is less than an hour old
+		// or if we have a cached error that is less than an hour old
+		lastFetched, ok := cli.ProfileCache.lastFetched[signalID.String()]
+		if ok && time.Since(lastFetched) < 1*time.Hour {
+			profile, ok := cli.ProfileCache.profiles[signalID.String()]
+			if ok {
+				return profile, nil
+			}
+			err, ok := cli.ProfileCache.errors[signalID.String()]
+			if ok {
+				return nil, *err
+			}
 		}
 	}
 

--- a/pkg/signalmeow/receiving.go
+++ b/pkg/signalmeow/receiving.go
@@ -654,6 +654,18 @@ func (cli *Client) incomingAPIMessageHandler(ctx context.Context, req *signalpb.
 					Messages: content.SyncMessage.GetRead(),
 				})
 			}
+			if content.SyncMessage.FetchLatest != nil {
+				switch fetchType := content.SyncMessage.FetchLatest.GetType(); fetchType {
+				case signalpb.SyncMessage_FetchLatest_LOCAL_PROFILE:
+					cli.handleEvent(&events.Profile{
+						Sender: theirUUID,
+					})
+				default:
+					log.Warn().
+						Stringer("type", fetchType).
+						Msg("Received unhandled FetchLatest type")
+				}
+			}
 
 		}
 

--- a/portal.go
+++ b/portal.go
@@ -874,7 +874,7 @@ func (portal *Portal) handleSignalDataMessage(source *User, sender *Puppet, msg 
 		Uint64("msg_ts", msg.GetTimestamp()).
 		Logger().WithContext(context.TODO())
 	// Always update sender info when we receive a message from them, there's caching inside the function
-	sender.UpdateInfo(genericCtx, source)
+	sender.UpdateInfo(genericCtx, source, false)
 	// Handle earlier missed group changes here.
 	// If this message is a group change, don't handle it here, it's handled below.
 	if msg.GetGroupV2().GetGroupChange() == nil && portal.Revision < msg.GetGroupV2().GetRevision() {
@@ -1718,7 +1718,7 @@ func (portal *Portal) CreateMatrixRoom(ctx context.Context, user *User, groupRev
 	var groupInfo *signalmeow.Group
 	if portal.IsPrivateChat() {
 		dmPuppet = portal.GetDMPuppet()
-		dmPuppet.UpdateInfo(ctx, user)
+		dmPuppet.UpdateInfo(ctx, user, false)
 		portal.UpdateDMInfo(ctx, false)
 	} else {
 		groupInfo = portal.UpdateGroupInfo(ctx, user, nil, groupRevision, true)
@@ -2137,7 +2137,7 @@ func (portal *Portal) SyncParticipants(ctx context.Context, source *User, info *
 			log.Warn().Stringer("signal_user_id", member.UserID).Msg("Couldn't get puppet for group member")
 			continue
 		}
-		puppet.UpdateInfo(ctx, source)
+		puppet.UpdateInfo(ctx, source, false)
 		intent := puppet.IntentFor(portal)
 		if member.UserID != source.SignalID && portal.MXID != "" {
 			userIDs[intent.UserID] = ((int)(member.Role) >> 1) * 50

--- a/puppet.go
+++ b/puppet.go
@@ -232,7 +232,7 @@ func (puppet *Puppet) GetAvatarURL() id.ContentURI {
 	return puppet.AvatarURL
 }
 
-func (puppet *Puppet) UpdateInfo(ctx context.Context, source *User) {
+func (puppet *Puppet) UpdateInfo(ctx context.Context, source *User, forceFetchProfile bool) {
 	log := zerolog.Ctx(ctx).With().
 		Str("function", "Puppet.UpdateInfo").
 		Stringer("signal_user_id", puppet.SignalID).
@@ -240,7 +240,7 @@ func (puppet *Puppet) UpdateInfo(ctx context.Context, source *User) {
 	ctx = log.WithContext(ctx)
 	var err error
 	log.Debug().Msg("Fetching contact info to update puppet")
-	info, err := source.Client.ContactByID(ctx, puppet.SignalID)
+	info, err := source.Client.ContactByID(ctx, puppet.SignalID, forceFetchProfile)
 	if err != nil {
 		log.Err(err).Msg("Failed to fetch contact info")
 		return

--- a/user.go
+++ b/user.go
@@ -750,7 +750,19 @@ func (user *User) handleContactList(evt *events.ContactList) {
 		if puppet == nil {
 			return
 		}
-		puppet.UpdateInfo(ctx, user)
+		puppet.UpdateInfo(ctx, user, false)
+	}
+}
+
+func (user *User) handleProfile(evt *events.Profile) {
+	ctx := user.log.With().Str("action", "handle profile").Logger().WithContext(context.TODO())
+	puppet := user.bridge.GetPuppetBySignalID(evt.Sender)
+	if puppet != nil {
+		puppet.UpdateInfo(ctx, user, true)
+	} else {
+		zerolog.Ctx(ctx).Warn().
+			Stringer("signal_user_id", evt.Sender).
+			Msg("No puppet found for sender")
 	}
 }
 
@@ -781,6 +793,8 @@ func (user *User) eventHandler(rawEvt events.SignalEvent) {
 		portal.sendMainIntentMessage(context.TODO(), content)
 	case *events.ContactList:
 		user.handleContactList(evt)
+	case *events.Profile:
+		user.handleProfile(evt)
 	default:
 		user.log.Warn().Type("event_type", evt).Msg("Unrecognized event type from signalmeow")
 	}


### PR DESCRIPTION
This causes Signal profile changes to be fetched as they happen, but only for logged-in users.

Helps with #476