### PR TITLE
Pass arguments to docker-run.sh on to mautrix-signal

### DIFF
--- a/docker-run.sh
+++ b/docker-run.sh
@@ -6,7 +6,7 @@ fi
 
 # Define functions.
 function fixperms {
-	chown -R $UID:$GID /data
+	chown -R "$UID:$GID" /data
 
 	# /opt/mautrix-signal is read-only, so disable file logging if it's pointing there.
 	if [[ "$(yq e '.logging.writers[1].filename' /data/config.yaml)" == "./logs/mautrix-signal.log" ]]; then
@@ -31,16 +31,16 @@ if [[ ! -f /data/registration.yaml ]]; then
 	exit
 fi
 
-cd /data
+cd /data || exit 1
 fixperms
 
 EXE=/usr/bin/mautrix-signal
 DLV=/usr/bin/dlv
 if [ -x "$DLV" ]; then
-    if [ "$DBGWAIT" != 1 ]; then
-        NOWAIT=1
-    fi
-    EXE="${DLV} exec ${EXE} ${NOWAIT:+--continue --accept-multiclient} --api-version 2 --headless -l :4040"
+	if [ "$DBGWAIT" != 1 ]; then
+		NOWAIT=1
+	fi
+	EXE="${DLV} exec ${EXE} ${NOWAIT:+--continue --accept-multiclient} --api-version 2 --headless -l :4040"
 fi
 
-exec su-exec $UID:$GID $EXE
+exec su-exec "$UID:$GID" "$EXE" "$@"


### PR DESCRIPTION
This PR extends `docker-run.sh` so that it passes additional arguments on to mautrix-signal (once the requisite files exist and the bridge is started). In particular, this should make it easier to use CLI flags such as `--ignore-unsupported-server` when using the Docker image (by overriding `CMD`).

Further, it fixes some inconsistent indentation and ShellCheck warnings concerning missing variable quoting.

Closes #474