### PR TITLE
Minor incoming messages refactor and send m.notice on decryption errors

### DIFF
--- a/pkg/signalmeow/events/message.go
+++ b/pkg/signalmeow/events/message.go
@@ -28,12 +28,13 @@ type SignalEvent interface {
 	isSignalEvent()
 }
 
-func (*ChatEvent) isSignalEvent()   {}
-func (*Receipt) isSignalEvent()     {}
-func (*ReadSelf) isSignalEvent()    {}
-func (*Call) isSignalEvent()        {}
-func (*ContactList) isSignalEvent() {}
-func (*ACIFound) isSignalEvent()    {}
+func (*ChatEvent) isSignalEvent()       {}
+func (*DecryptionError) isSignalEvent() {}
+func (*Receipt) isSignalEvent()         {}
+func (*ReadSelf) isSignalEvent()        {}
+func (*Call) isSignalEvent()            {}
+func (*ContactList) isSignalEvent()     {}
+func (*ACIFound) isSignalEvent()        {}
 
 type MessageInfo struct {
 	Sender uuid.UUID
@@ -45,6 +46,11 @@ type MessageInfo struct {
 type ChatEvent struct {
 	Info  MessageInfo
 	Event signalpb.ChatEventContent
+}
+
+type DecryptionError struct {
+	Sender uuid.UUID
+	Err    error
 }
 
 type Receipt struct {

--- a/pkg/signalmeow/receiving.go
+++ b/pkg/signalmeow/receiving.go
@@ -578,6 +578,8 @@ func (cli *Client) decryptUnidentifiedSenderEnvelope(ctx context.Context, destin
 		if err != nil {
 			if strings.Contains(err.Error(), "self send of a sealed sender message") {
 				log.Debug().Msg("Message sent by us, ignoring")
+			} else if strings.Contains(err.Error(), "message with old counter") {
+				log.Info().Msg("Duplicate message, ignoring (sealedSenderDecrypt)")
 			} else {
 				log.Err(err).Msg("sealedSenderDecrypt error")
 			}


### PR DESCRIPTION
We were falling through without propagating errors anywhere. I caught most decryption errors and send them along in the new Err field in DecryptionResult, to be then passed along to the bridge as a new type of chat event.

I'm going to do another pass to catch any last decryption errors, but this should be a big improvement over what we currently do.