### PR TITLE
Full sync on portal creation, invite handling

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -20,8 +20,8 @@
     * [x] Name
     * [x] Avatar
     * [x] Topic
-  * [ ] Membership actions
-    * [ ] Join (accepting invites)
+  * [x] Membership actions
+    * [x] Join (accepting invites)
     * [x] Invite
     * [x] Leave
     * [x] Kick/Ban/Unban

--- a/commands.go
+++ b/commands.go
@@ -279,7 +279,7 @@ func fnPM(ce *WrappedCommandEvent) {
 		portal.MXID = ""
 	}
 
-	if err = portal.CreateMatrixRoom(ce.Ctx, user, 0); err != nil {
+	if err = portal.CreateMatrixRoom(ce.Ctx, user, 0, nil); err != nil {
 		ce.ZLog.Err(err).Msg("Failed to create portal room")
 		ce.Reply("Error creating Matrix room for portal to +%d", number)
 	} else {

--- a/commands.go
+++ b/commands.go
@@ -279,7 +279,7 @@ func fnPM(ce *WrappedCommandEvent) {
 		portal.MXID = ""
 	}
 
-	if err = portal.CreateMatrixRoom(ce.Ctx, user, 0, nil); err != nil {
+	if err = portal.CreateMatrixRoom(ce.Ctx, user, 0, nil, nil); err != nil {
 		ce.ZLog.Err(err).Msg("Failed to create portal room")
 		ce.Reply("Error creating Matrix room for portal to +%d", number)
 	} else {

--- a/pkg/signalmeow/groups.go
+++ b/pkg/signalmeow/groups.go
@@ -154,7 +154,7 @@ type RequestingMember struct {
 	Timestamp  uint64
 }
 
-type PromotePendingMembers struct {
+type PromotePendingMember struct {
 	ACI        uuid.UUID
 	ProfileKey libsignalgo.ProfileKey
 }
@@ -178,7 +178,7 @@ type BannedMember struct {
 type GroupChange struct {
 	groupMasterKey types.SerializedGroupMasterKey
 
-	SourceACI                          uuid.UUID
+	SourceServiceID                    libsignalgo.ServiceID
 	Revision                           uint32
 	AddMembers                         []*AddMember
 	DeleteMembers                      []*uuid.UUID
@@ -186,7 +186,7 @@ type GroupChange struct {
 	ModifyMemberProfileKeys            []*ProfileKeyMember
 	AddPendingMembers                  []*PendingMember
 	DeletePendingMembers               []*libsignalgo.ServiceID
-	PromotePendingMembers              []*GroupMember
+	PromotePendingMembers              []*PromotePendingMember
 	ModifyTitle                        *string
 	ModifyAvatar                       *string
 	ModifyDisappearingMessagesDuration *uint32
@@ -858,13 +858,10 @@ func (cli *Client) decryptGroupChange(ctx context.Context, encryptedGroupChange 
 		log.Err(err).Msg("Couldn't decrypt source serviceID")
 		return nil, err
 	}
-	if sourceServiceID.Type != libsignalgo.ServiceIDTypeACI {
-		return nil, fmt.Errorf("wrong serviceid kind: expected aci, got pni")
-	}
 	decryptedGroupChange := &GroupChange{
-		groupMasterKey: groupMasterKey,
-		Revision:       encryptedActions.Revision,
-		SourceACI:      sourceServiceID.UUID,
+		groupMasterKey:  groupMasterKey,
+		Revision:        encryptedActions.Revision,
+		SourceServiceID: sourceServiceID,
 	}
 
 	if encryptedActions.ModifyTitle != nil {
@@ -972,7 +969,9 @@ func (cli *Client) decryptGroupChange(ctx context.Context, encryptedGroupChange 
 	}
 
 	for _, deletePendingMember := range encryptedActions.DeletePendingMembers {
+		log.Debug().Msg("Decrypting pending Member")
 		if deletePendingMember == nil {
+			log.Debug().Msg("Pending Member is nil")
 			continue
 		}
 		encryptedUserID := libsignalgo.UUIDCiphertext(deletePendingMember.DeletedUserId)
@@ -992,7 +991,7 @@ func (cli *Client) decryptGroupChange(ctx context.Context, encryptedGroupChange 
 		if err != nil {
 			return nil, err
 		}
-		decryptedGroupChange.PromotePendingMembers = append(decryptedGroupChange.PromotePendingMembers, &GroupMember{
+		decryptedGroupChange.PromotePendingMembers = append(decryptedGroupChange.PromotePendingMembers, &PromotePendingMember{
 			ACI:        *aci,
 			ProfileKey: *profileKey,
 		})

--- a/pkg/signalmeow/groups.go
+++ b/pkg/signalmeow/groups.go
@@ -1886,3 +1886,28 @@ func (cli *Client) decryptGroupChanges(ctx context.Context, encryptedGroupChange
 	}
 	return groupChanges, nil
 }
+
+func (group *Group) UndoAddOrInviteChange(ctx context.Context, groupChange *GroupChange) {
+	if len(groupChange.AddMembers) > 0 || len(groupChange.AddPendingMembers) > 0 || len(groupChange.PromoteRequestingMembers) > 0 {
+		group.Revision--
+	}
+	for i, members := range group.Members {
+		for _, addMember := range groupChange.AddMembers {
+			if addMember.ACI == members.ACI {
+				group.Members = append(group.Members[:i], group.Members[i+1:]...)
+			}
+		}
+		for _, addMember := range groupChange.PromoteRequestingMembers {
+			if addMember.ACI == members.ACI {
+				group.Members = append(group.Members[:i], group.Members[i+1:]...)
+			}
+		}
+	}
+	for i, pendingMember := range group.PendingMembers {
+		for _, addPendingMember := range groupChange.AddPendingMembers {
+			if addPendingMember.ServiceID == pendingMember.ServiceID {
+				group.PendingMembers = append(group.PendingMembers[:i], group.PendingMembers[i+1:]...)
+			}
+		}
+	}
+}

--- a/pkg/signalmeow/store/container.go
+++ b/pkg/signalmeow/store/container.go
@@ -39,6 +39,7 @@ FROM signalmeow_device
 `
 
 const getDeviceQuery = getAllDevicesQuery + " WHERE aci_uuid=$1"
+const deviceByPNIQuery = getAllDevicesQuery + "Where pni_uuid=$1"
 
 func (c *Container) Upgrade(ctx context.Context) error {
 	return c.db.Upgrade(ctx)
@@ -113,6 +114,14 @@ func (c *Container) GetAllDevices(ctx context.Context) ([]*Device, error) {
 // If the device is not found, nil is returned instead.
 func (c *Container) DeviceByACI(ctx context.Context, aci uuid.UUID) (*Device, error) {
 	sess, err := c.scanDevice(c.db.QueryRow(ctx, getDeviceQuery, aci))
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, nil
+	}
+	return sess, err
+}
+
+func (c *Container) DeviceByPNI(ctx context.Context, pni uuid.UUID) (*Device, error) {
+	sess, err := c.scanDevice(c.db.QueryRow(ctx, deviceByPNIQuery, pni))
 	if errors.Is(err, sql.ErrNoRows) {
 		return nil, nil
 	}

--- a/provisioning.go
+++ b/provisioning.go
@@ -290,7 +290,7 @@ func (prov *ProvisioningAPI) StartPM(w http.ResponseWriter, r *http.Request) {
 
 	portal := user.GetPortalByChatID(resp.ChatID.UUID)
 	if portal.MXID == "" {
-		if err := portal.CreateMatrixRoom(r.Context(), user, 0); err != nil {
+		if err := portal.CreateMatrixRoom(r.Context(), user, 0, nil); err != nil {
 			log.Err(err).Msg("error looking up contact")
 			jsonResponse(w, http.StatusInternalServerError, Error{
 				Success: false,

--- a/provisioning.go
+++ b/provisioning.go
@@ -290,7 +290,7 @@ func (prov *ProvisioningAPI) StartPM(w http.ResponseWriter, r *http.Request) {
 
 	portal := user.GetPortalByChatID(resp.ChatID.UUID)
 	if portal.MXID == "" {
-		if err := portal.CreateMatrixRoom(r.Context(), user, 0, nil); err != nil {
+		if err := portal.CreateMatrixRoom(r.Context(), user, 0, nil, nil); err != nil {
 			log.Err(err).Msg("error looking up contact")
 			jsonResponse(w, http.StatusInternalServerError, Error{
 				Success: false,


### PR DESCRIPTION
- refactor SyncParticipants and updatePowerLevelsAndJoinRule to
- set power levels and join rule in initial state
- sync pending/requesting/banned members on room creation
- bridge room creation with actual group creator, if known
- support identifying logged-in users by PNI
- support for group invites, accepting or rejecting invites
- changed SourceACI to SourceServiceID; PNI type SourceServiceIDs seem to exist - not sure why.

Some oddities: if the group creation is double-puppeted, the bridge bot will say "Hi, I'm a Signal bridge bot". Not sure how to turn that off. Group creation by ghost is not a problem
Sometimes the bridge bot will double down on group creation invites