### PR TITLE
feat: Handle arguments to build.sh

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 git submodule init
 git submodule update
-make
+make GO_EXTRA_OPTS="$*"


### PR DESCRIPTION
- Pass on arguments to build.sh to the Makefile
- Improve Makefile, so it doesn't need to copy the library