### PR TITLE
rename portals -> groups in sync command description

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -543,7 +543,7 @@ var cmdSync = &commands.FullHandler{
 	Help: commands.HelpMeta{
 		Section:     HelpSectionMiscellaneous,
 		Description: "Synchronize Signal bridge data",
-		Args:        "<space/portals>",
+		Args:        "<space/groups>",
 	},
 	RequiresLogin: true,
 }


### PR DESCRIPTION
Description and actual command were inconsistent. Sorry.