### PR TITLE
Block until stop completes

### DIFF
--- a/pkg/signalmeow/client.go
+++ b/pkg/signalmeow/client.go
@@ -48,8 +48,10 @@ type Client struct {
 
 	AuthedWS             *web.SignalWebsocket
 	UnauthedWS           *web.SignalWebsocket
-	WSCancel             context.CancelFunc
 	lastConnectionStatus SignalConnectionStatus
+
+	loopCancel context.CancelFunc
+	loopWg     sync.WaitGroup
 
 	EventHandler func(events.SignalEvent)
 


### PR DESCRIPTION
Currently the disconnect/stop bridge call will complete before all the loops have returned. This switches them all to use a shared cancelable context and wait group to block on stop until all loops exit.