### PR TITLE
build: use `serviceid_clang.go` when building for arm64 windows

### DIFF
--- a/pkg/libsignalgo/serviceid_clang.go
+++ b/pkg/libsignalgo/serviceid_clang.go
@@ -1,4 +1,4 @@
-//go:build darwin || android || ios
+//go:build darwin || android || ios || (windows && arm64)
 
 package libsignalgo
 

--- a/pkg/libsignalgo/serviceid_gcc.go
+++ b/pkg/libsignalgo/serviceid_gcc.go
@@ -1,4 +1,4 @@
-//go:build !(darwin || android || ios)
+//go:build !(darwin || android || ios || (windows && arm64))
 
 package libsignalgo
 


### PR DESCRIPTION
The workaround for https://github.com/golang/go/issues/7270 is seemingly being applied to ARM64 Windows, wherein we use [the llvm-mingw toolchain](https://github.com/mstorsjo/llvm-mingw). This breaks the build:

> ...\authcredential.go:54:3: cannot use NewACIServiceID(aci).CFixedBytes() (value of pointer type cPNIType) as *_Ctype_SignalServiceIdFixedWidthBinaryBytes value in variable declaration
> ...\authcredential.go:55:3: cannot use NewPNIServiceID(pni).CFixedBytes() (value of pointer type cPNIType) as *_Ctype_SignalServiceIdFixedWidthBinaryBytes value in variable declaration