### PR TITLE
build.sh: fail if prior steps fail

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+set -e
 ./build-rust.sh
 cp -f pkg/libsignalgo/libsignal/target/release/libsignal_ffi.a .
 LIBRARY_PATH=.:$LIBRARY_PATH ./build-go.sh


### PR DESCRIPTION
Unless it was intended that a compilation failure in the bindings would not prevent then trying to use the not-actually-compiled bindings for the rest of the build?