### PR TITLE
capabilities: bump bridge info version

### DIFF
--- a/pkg/connector/capabilities.go
+++ b/pkg/connector/capabilities.go
@@ -231,5 +231,5 @@ func (s *SignalConnector) GetCapabilities() *bridgev2.NetworkGeneralCapabilities
 }
 
 func (s *SignalConnector) GetBridgeInfoVersion() (info, capabilities int) {
-	return 1, 6
+	return 1, 7
 }


### PR DESCRIPTION
Bridge info version was bumped before the other PR was merged so it didn't backfill the delete chat update.