### PR TITLE
capabilities: drop webp to only partial support

### DIFF
--- a/pkg/connector/capabilities.go
+++ b/pkg/connector/capabilities.go
@@ -75,8 +75,7 @@ var signalCaps = &event.RoomFeatures{
 				"image/gif":  event.CapLevelFullySupported,
 				"image/png":  event.CapLevelFullySupported,
 				"image/jpeg": event.CapLevelFullySupported,
-				// Signal clients will only render static webp, so apng is preferred
-				"image/webp": event.CapLevelPartialSupport,
+				"image/webp": event.CapLevelFullySupported,
 				"image/bmp":  event.CapLevelFullySupported,
 			},
 			MaxWidth:         4096,

--- a/pkg/connector/capabilities.go
+++ b/pkg/connector/capabilities.go
@@ -75,6 +75,7 @@ var signalCaps = &event.RoomFeatures{
 				"image/gif":  event.CapLevelFullySupported,
 				"image/png":  event.CapLevelFullySupported,
 				"image/jpeg": event.CapLevelFullySupported,
+				// Signal clients will only render static webp, so apng is preferred
 				"image/webp": event.CapLevelPartialSupport,
 				"image/bmp":  event.CapLevelFullySupported,
 			},
@@ -111,6 +112,7 @@ var signalCaps = &event.RoomFeatures{
 		},
 		event.CapMsgSticker: {
 			MimeTypes: map[string]event.CapabilitySupportLevel{
+				// Signal clients will only render static webp, so apng is preferred
 				"image/webp": event.CapLevelPartialSupport,
 				"image/png":  event.CapLevelFullySupported,
 				"image/apng": event.CapLevelFullySupported,

--- a/pkg/connector/capabilities.go
+++ b/pkg/connector/capabilities.go
@@ -38,7 +38,7 @@ func supportedIfFFmpeg() event.CapabilitySupportLevel {
 }
 
 func capID() string {
-	base := "fi.mau.signal.capabilities.2025_12_09"
+	base := "fi.mau.signal.capabilities.2026_05_12"
 	if ffmpeg.Supported() {
 		return base + "+ffmpeg"
 	}
@@ -75,7 +75,7 @@ var signalCaps = &event.RoomFeatures{
 				"image/gif":  event.CapLevelFullySupported,
 				"image/png":  event.CapLevelFullySupported,
 				"image/jpeg": event.CapLevelFullySupported,
-				"image/webp": event.CapLevelFullySupported,
+				"image/webp": event.CapLevelPartialSupport,
 				"image/bmp":  event.CapLevelFullySupported,
 			},
 			MaxWidth:         4096,
@@ -111,7 +111,7 @@ var signalCaps = &event.RoomFeatures{
 		},
 		event.CapMsgSticker: {
 			MimeTypes: map[string]event.CapabilitySupportLevel{
-				"image/webp": event.CapLevelFullySupported,
+				"image/webp": event.CapLevelPartialSupport,
 				"image/png":  event.CapLevelFullySupported,
 				"image/apng": event.CapLevelFullySupported,
 				"image/gif":  supportedIfFFmpeg(),
@@ -236,5 +236,5 @@ func (s *SignalConnector) GetCapabilities() *bridgev2.NetworkGeneralCapabilities
 }
 
 func (s *SignalConnector) GetBridgeInfoVersion() (info, capabilities int) {
-	return 1, 7
+	return 1, 8
 }


### PR DESCRIPTION
Signal doesn't animate webp, so clients may chose to prefer APNGs instead.

### Checklist

* [x] I have read and followed the contributing guidelines at <https://docs.mau.fi/bridges/general/contributing.html>
