### PR TITLE
Security: Potential Memory Leak in C String Allocation

### DIFF
--- a/pkg/libsignalgo/accountentropy.go
+++ b/pkg/libsignalgo/accountentropy.go
@@ -29,9 +29,11 @@ type AccountEntropyPool string
 
 func (aep AccountEntropyPool) DeriveSVRKey() ([]byte, error) {
 	var out [C.SignalSVR_KEY_LEN]byte
+	cstr := C.CString(string(aep))
+	defer C.free(unsafe.Pointer(cstr))
 	signalFfiError := C.signal_account_entropy_pool_derive_svr_key(
 		(*[C.SignalSVR_KEY_LEN]C.uint8_t)(unsafe.Pointer(&out)),
-		C.CString(string(aep)),
+		cstr,
 	)
 	runtime.KeepAlive(aep)
 	if signalFfiError != nil {
@@ -42,9 +44,11 @@ func (aep AccountEntropyPool) DeriveSVRKey() ([]byte, error) {
 
 func (aep AccountEntropyPool) DeriveBackupKey() ([]byte, error) {
 	var out [C.SignalBACKUP_KEY_LEN]byte
+	cstr := C.CString(string(aep))
+	defer C.free(unsafe.Pointer(cstr))
 	signalFfiError := C.signal_account_entropy_pool_derive_backup_key(
 		(*[C.SignalBACKUP_KEY_LEN]C.uint8_t)(unsafe.Pointer(&out)),
-		C.CString(string(aep)),
+		cstr,
 	)
 	runtime.KeepAlive(aep)
 	if signalFfiError != nil {


### PR DESCRIPTION
## Summary

Security: Potential Memory Leak in C String Allocation

## Problem

**Severity**: `Medium` | **File**: `pkg/libsignalgo/accountentropy.go:L37`

In `accountentropy.go`, `C.CString(string(aep))` is used to convert Go strings to C strings, but there is no corresponding `C.free()` call to deallocate the memory. This results in a memory leak every time `DeriveSVRKey()` or `DeriveBackupKey()` is called. The `runtime.KeepAlive(aep)` only keeps the Go string alive but does not manage the C string memory.

## Solution

Use `C.CString()` with a defer to free the allocated memory using `C.free(unsafe.Pointer(cstr))`, or use a helper function that manages the lifecycle properly.

## Changes

- `pkg/libsignalgo/accountentropy.go` (modified)