### PR TITLE
handle*: insert stub message rows for old edit events

### DIFF
--- a/pkg/connector/handlematrix.go
+++ b/pkg/connector/handlematrix.go
@@ -180,10 +180,41 @@ func (s *SignalClient) HandleMatrixEdit(ctx context.Context, msg *bridgev2.Matri
 	if err != nil {
 		return bridgev2.WrapErrorInStatus(err).WithSendNotice(true)
 	}
+	prevID := msg.EditTarget.ID
 	msg.EditTarget.ID = signalid.MakeMessageID(s.Client.Store.ACI, ts)
 	msg.EditTarget.Metadata = &signalid.MessageMetadata{ContainsAttachments: len(converted.Attachments) > 0}
 	msg.EditTarget.EditCount++
+	if prevID != msg.EditTarget.ID {
+		err = s.Main.Bridge.DB.Message.Update(ctx, msg.EditTarget)
+		if err != nil {
+			zerolog.Ctx(ctx).Err(err).Msg("Failed to save message after editing")
+		} else {
+			saveEditStub(ctx, s.Main.Bridge, prevID, msg.EditTarget)
+		}
+	}
 	return nil
+}
+
+// saveEditStub saves a placeholder message row pointing at the pre-edit ID of a message, such that
+// duplicate checks on incoming edits find it and are dropped. This is necessary because the first
+// time we see an edit it modifies the ID in place.
+func saveEditStub(ctx context.Context, bridge *bridgev2.Bridge, prevID networkid.MessageID, target *database.Message) {
+	stub := &database.Message{
+		ID:         prevID,
+		PartID:     editStubPartID,
+		Room:       target.Room,
+		SenderID:   target.SenderID,
+		SenderMXID: target.SenderMXID,
+		Timestamp:  target.Timestamp,
+	}
+	stub.SetFakeMXID()
+	err := bridge.DB.Message.Insert(ctx, stub)
+	if err != nil {
+		zerolog.Ctx(ctx).Warn().Err(err).
+			Str("prev_message_id", string(prevID)).
+			Str("message_id", string(target.ID)).
+			Msg("Failed to save stub row for pre-edit message ID")
+	}
 }
 
 func (s *SignalClient) PreHandleMatrixReaction(ctx context.Context, msg *bridgev2.MatrixReaction) (bridgev2.MatrixReactionPreResponse, error) {

--- a/pkg/connector/handlesignal.go
+++ b/pkg/connector/handlesignal.go
@@ -392,8 +392,11 @@ func (evt *Bv2ChatEvent) ConvertEdit(ctx context.Context, portal *bridgev2.Porta
 	converted := evt.s.Main.MsgConv.ToMatrix(ctx, evt.s.Client, portal, evt.Info.Sender, intent, editMsg.GetDataMessage(), nil)
 	// TODO can anything other than the text be edited?
 	editPart := converted.Parts[len(converted.Parts)-1].ToEditPart(existing[len(existing)-1])
-	editPart.Part.EditCount++
 	prevID := editPart.Part.ID
+	// Clone the database message struct to avoid mutating the ID.
+	// The ID from the original struct is used for AddedParts (we specifically want the old ID for that)
+	editPart.Part = ptr.Clone(editPart.Part)
+	editPart.Part.EditCount++
 	editPart.Part.ID = signalid.MakeMessageID(evt.Info.Sender, editMsg.GetDataMessage().GetTimestamp())
 	convertedEdit := &bridgev2.ConvertedEdit{
 		ModifiedParts: []*bridgev2.ConvertedEditPart{editPart},

--- a/pkg/connector/handlesignal.go
+++ b/pkg/connector/handlesignal.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
+	"slices"
 	"strings"
 	"time"
 
@@ -358,20 +359,49 @@ func (evt *Bv2ChatEvent) ConvertMessage(ctx context.Context, portal *bridgev2.Po
 	return converted, nil
 }
 
+const editStubPartID networkid.PartID = "editstub"
+
+func isEditStub(msg *database.Message) bool {
+	return msg.PartID == editStubPartID
+}
+
+// editStubMessage returns a non-bridged message part which is saved as a placeholder row pointing
+// at the pre-edit ID of a message, such that duplicate checks on incoming edits find it and are
+// dropped. This is necessary because the first time we see an edit it modifies the ID in place.
+func editStubMessage() *bridgev2.ConvertedMessage {
+	return &bridgev2.ConvertedMessage{
+		Parts: []*bridgev2.ConvertedMessagePart{{
+			ID:         editStubPartID,
+			Type:       event.EventMessage,
+			Content:    &event.MessageEventContent{},
+			DontBridge: true,
+		}},
+	}
+}
+
 func (evt *Bv2ChatEvent) ConvertEdit(ctx context.Context, portal *bridgev2.Portal, intent bridgev2.MatrixAPI, existing []*database.Message) (*bridgev2.ConvertedEdit, error) {
 	editMsg, ok := evt.Event.(*signalpb.EditMessage)
 	if !ok {
 		return nil, fmt.Errorf("ConvertEdit() called for non-EditMessage event")
+	}
+	existing = slices.DeleteFunc(slices.Clone(existing), isEditStub)
+	if len(existing) == 0 {
+		return nil, fmt.Errorf("%w: edit target has already been edited", bridgev2.ErrIgnoringRemoteEvent)
 	}
 	// TODO tell converter about existing parts to avoid reupload?
 	converted := evt.s.Main.MsgConv.ToMatrix(ctx, evt.s.Client, portal, evt.Info.Sender, intent, editMsg.GetDataMessage(), nil)
 	// TODO can anything other than the text be edited?
 	editPart := converted.Parts[len(converted.Parts)-1].ToEditPart(existing[len(existing)-1])
 	editPart.Part.EditCount++
+	prevID := editPart.Part.ID
 	editPart.Part.ID = signalid.MakeMessageID(evt.Info.Sender, editMsg.GetDataMessage().GetTimestamp())
-	return &bridgev2.ConvertedEdit{
+	convertedEdit := &bridgev2.ConvertedEdit{
 		ModifiedParts: []*bridgev2.ConvertedEditPart{editPart},
-	}, nil
+	}
+	if prevID != editPart.Part.ID {
+		convertedEdit.AddedParts = editStubMessage()
+	}
+	return convertedEdit, nil
 }
 
 func (evt *Bv2ChatEvent) GetStreamOrder() int64 {


### PR DESCRIPTION
This prevents a re-delivery of an old edit breaking the bridge due to duplicate network ID error as the original message row will be updated by the edit.
