### PR TITLE
signalmeow/storageservice: store own profile key from account record

### DIFF
--- a/pkg/signalmeow/storageservice.go
+++ b/pkg/signalmeow/storageservice.go
@@ -137,6 +137,12 @@ func (cli *Client) processStorageInTxn(ctx context.Context, update *StorageUpdat
 		case *signalpb.StorageRecord_Account:
 			log.Trace().Any("account_record", data.Account).Msg("Found account record")
 			cli.Store.AccountRecord = data.Account
+			if len(data.Account.ProfileKey) == libsignalgo.ProfileKeyLength {
+				err := cli.Store.RecipientStore.StoreProfileKey(ctx, cli.Store.ACI, libsignalgo.ProfileKey(data.Account.ProfileKey))
+				if err != nil {
+					return fmt.Errorf("failed to store own profile key: %w", err)
+				}
+			}
 			err := cli.Store.DeviceStore.PutDevice(ctx, &cli.Store.DeviceData)
 			if err != nil {
 				return fmt.Errorf("failed to save device after receiving account record: %w", err)


### PR DESCRIPTION
The bridge's own profile key is only written at link time, so it goes stale once the primary device rotates it, which breaks expiring profile key credential fetches and therefore group creation.

Adopt the profile key from the storage service account record, like contact records already do.
