### PR TITLE
msgconv/from-matrix: send long messages as long text attachments

### DIFF
--- a/pkg/msgconv/from-matrix.go
+++ b/pkg/msgconv/from-matrix.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
+	"unicode/utf8"
 
 	"github.com/rs/zerolog"
 	"go.mau.fi/util/exmime"
@@ -37,6 +38,11 @@ import (
 	"go.mau.fi/mautrix-signal/pkg/signalmeow"
 	signalpb "go.mau.fi/mautrix-signal/pkg/signalmeow/protobuf"
 )
+
+const longTextMimeType = "text/x-signal-plain"
+const longTextFileName = "long-message.txt"
+const signalTextMaxLength = 2 * 1024      // in UTF-8 bytes, Signal clients silently drop messages with a longer body
+const signalLongTextMaxLength = 64 * 1024 // Signal clients refuse to send or process bigger long text attachments
 
 func (mc *MessageConverter) ToSignal(
 	ctx context.Context,
@@ -139,7 +145,46 @@ func (mc *MessageConverter) ToSignal(
 	default:
 		return nil, fmt.Errorf("%w %s", bridgev2.ErrUnsupportedMessageType, content.MsgType)
 	}
+	if err := mc.convertLongTextToSignal(ctx, dm); err != nil {
+		return nil, err
+	}
 	return dm, nil
+}
+
+func (mc *MessageConverter) convertLongTextToSignal(ctx context.Context, dm *signalpb.DataMessage) error {
+	body := dm.GetBody()
+	if len(body) <= signalTextMaxLength {
+		return nil
+	} else if len(body) > signalLongTextMaxLength {
+		return fmt.Errorf("message body is too long (%d bytes, maximum is %d)", len(body), signalLongTextMaxLength)
+	}
+	zerolog.Ctx(ctx).Debug().
+		Int("body_size", len(body)).
+		Msg("Uploading message body as long text attachment")
+	att, err := getClient(ctx).UploadAttachment(ctx, []byte(body))
+	if err != nil {
+		zerolog.Ctx(ctx).Err(err).Msg("Failed to upload long text")
+		return fmt.Errorf("%w (long text): %w", bridgev2.ErrMediaReuploadFailed, err)
+	}
+	att.ContentType = proto.String(longTextMimeType)
+	att.FileName = proto.String(longTextFileName)
+	dm.Attachments = append(dm.Attachments, att)
+	// Body ranges are intentionally left alone: receiving clients replace the body
+	// with the contents of the long text attachment before applying the ranges.
+	dm.Body = proto.String(truncateUTF8(body, signalTextMaxLength))
+	return nil
+}
+
+func truncateUTF8(str string, maxBytes int) string {
+	if len(str) <= maxBytes {
+		return str
+	}
+	end := maxBytes
+	// Don't cut in the middle of a multi-byte character
+	for end > 0 && !utf8.RuneStart(str[end]) {
+		end--
+	}
+	return str[:end]
 }
 
 func maybeInt[T constraints.Integer](v T) *T {

--- a/pkg/msgconv/from-matrix_test.go
+++ b/pkg/msgconv/from-matrix_test.go
@@ -1,0 +1,48 @@
+package msgconv
+
+import (
+	"strings"
+	"testing"
+	"unicode/utf8"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTruncateUTF8(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		max  int
+		out  string
+	}{
+		{name: "Empty", in: "", max: 5, out: ""},
+		{name: "Short", in: "hello", max: 10, out: "hello"},
+		{name: "ExactFit", in: "hello", max: 5, out: "hello"},
+		{name: "ASCII", in: "hello world", max: 5, out: "hello"},
+		{name: "MultiByteExactFit", in: "meow𝓂𝑒𝑜𝓌", max: 8, out: "meow𝓂"},
+		{name: "MultiByteSplit", in: "meow𝓂𝑒𝑜𝓌", max: 10, out: "meow𝓂"},
+		{name: "MultiByteTooSmall", in: "𝓂𝑒𝑜𝓌", max: 3, out: ""},
+		{name: "TwoByteSplit", in: "äää", max: 3, out: "ä"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			truncated := truncateUTF8(test.in, test.max)
+			assert.Equal(t, test.out, truncated)
+			assert.LessOrEqual(t, len(truncated), test.max)
+			assert.True(t, utf8.ValidString(truncated))
+			assert.True(t, strings.HasPrefix(test.in, truncated))
+		})
+	}
+}
+
+func TestTruncateUTF8_MaxLength(t *testing.T) {
+	// Bodies of multi-byte characters must always end up at or below the limit,
+	// even when the limit isn't a multiple of the character size.
+	fourByte := truncateUTF8(strings.Repeat("🐈", 1000), signalTextMaxLength)
+	assert.Equal(t, signalTextMaxLength, len(fourByte))
+	assert.True(t, utf8.ValidString(fourByte))
+
+	threeByte := truncateUTF8(strings.Repeat("あ", 1000), signalTextMaxLength)
+	assert.Equal(t, signalTextMaxLength-2, len(threeByte))
+	assert.True(t, utf8.ValidString(threeByte))
+}

--- a/pkg/msgconv/from-signal.go
+++ b/pkg/msgconv/from-signal.go
@@ -127,7 +127,7 @@ func (mc *MessageConverter) ToMatrix(
 		return cm
 	}
 	for i, att := range dm.GetAttachments() {
-		if att.GetContentType() != "text/x-signal-plain" || att.GetSize() > matrixTextMaxLength {
+		if att.GetContentType() != longTextMimeType || att.GetSize() > matrixTextMaxLength {
 			cm.Parts = append(cm.Parts, mc.convertAttachmentToMatrix(ctx, i, att, attMap))
 		} else {
 			longBody, err := mc.downloadSignalLongText(ctx, att, attMap)


### PR DESCRIPTION
Fixes #666.

Official Signal clients silently drop incoming messages whose body exceeds the
inline body limit, so long messages sent from Matrix were lost even though the
send reported success (and delivery receipts arrived, since those are sent
before content validation).

The limit is **2 KiB of UTF-8, not 2048 characters** — I got this wrong in the
issue, and it matters: a ~700 emoji or ~690 CJK character message was being
dropped too. Sources:

* Android: `SignalServiceMessageLimits.MAX_INLINE_BODY_SIZE_BYTES = 2.kibiBytes`,
  split via `String.splitByByteLength()` in `MessageUtil.getSplitMessage`;
  `EnvelopeContentValidator` rejects anything bigger on receive.
* Desktop: `MAX_MESSAGE_BODY_BYTE_LENGTH = 2 * KIBIBYTE` in
  `ts/util/longAttachment.std.ts`; the drop site in `MessageReceiver` compares
  `Buffer.byteLength(message.body)`.
* Both cap the long text attachment itself at 64 KiB
  (`MAX_BODY_ATTACHMENT_BYTE_LENGTH` / `MessageUtil.MAX_TOTAL_BODY_SIZE_BYTES`).

## Changes

`convertLongTextToSignal` runs after the msgtype switch in `ToSignal`, so it
covers plain text, captions on media, and edits (both `HandleMatrixMessage` and
`HandleMatrixEdit` go through `ToSignal`). When the body is over 2 KiB it
uploads the full text as a `text/x-signal-plain` attachment and truncates the
inline body — the same thing official clients do, and the inverse of the long
text handling that already exists in `ToMatrix`.

* `BodyRanges` is deliberately left untouched, since offsets stay relative to
  the full text: receiving clients (and this bridge's own `ToMatrix`) apply them
  after replacing the body with the attachment contents. Desktop does the same —
  it calls `trimBody(body)` and passes `bodyRanges` through unmodified.
* Truncation cuts on a rune boundary. Android cuts on a char boundary, Desktop
  on a grapheme cluster boundary; a rune boundary is a safe subset and needs no
  new dependency.
* Bodies over 64 KiB now fail with an error rather than producing an attachment
  every client would reject, so nothing is silently lost. Upload failures
  propagate as well, meaning the send is reported as failed instead of
  succeeding into the void.
* `from-signal.go` now uses the new shared `longTextMimeType` constant instead
  of a duplicated string literal.

## Testing

`gofmt` clean, `go vet ./pkg/msgconv/` passes, and the new `truncateUTF8` table
test covers the UTF-8 boundary cases (🐈×1000 truncates to exactly 2048 bytes,
あ×1000 to 2046, always valid UTF-8 and always a prefix of the original).

I could not link the `pkg/msgconv` test binary locally (no `libsignal_ffi`
built), so the table was executed standalone; CI should cover the real run.
